### PR TITLE
Simplify explainer video example

### DIFF
--- a/material/explainer-code-sample/README.md
+++ b/material/explainer-code-sample/README.md
@@ -1,17 +1,16 @@
 # Explainer Code Sample - Agriculture
 
-## Propoal what to show in explainer video
+## Proposal what to show in explainer video
 * File td.jsonld
 * Code example-client.js 
 
 
 ## Code Prerequisites
-* `npm install @node-wot/core`
-* `npm install @node-wot/binding-http`
+* `npm i @node-wot/cli`
 
 ## Running samples
-* `node example-client.js`
-* `node example-server.js`
+* `wot-servient example-server.js`
+* `wot-servient -c example-client.js`
 
 ## Code Syntax Highlighting
 

--- a/material/explainer-code-sample/example-client.js
+++ b/material/explainer-code-sample/example-client.js
@@ -1,30 +1,14 @@
-Servient = require("@node-wot/core").Servient
-HttpClientFactory = require("@node-wot/binding-http").HttpClientFactory
-
-Helpers = require("@node-wot/core").Helpers
-
-// create Servient and add HTTP binding
-let servient = new Servient();
-servient.addClientFactory(new HttpClientFactory(null));
-
-let wotHelper = new Helpers(servient);
-wotHelper.fetch("http://localhost:8080/Agriculture").then(async (td) => {
-    try {
-        servient.start().then((WoT) => {
-            WoT.consume(td).then((thing) => {
-                // read humidity and temperature sensor
-                thing.readProperty("humidity").then((h) => {
-                    console.log("Humidity: " + h);
-                });
-                thing.readProperty("temperature").then((t) => {
-                    console.log("Temperature: " + t);
-                });
-
-                // subscribe to tooDry event and turn on sprinkler system
-                // ...
-            });
+WoTHelpers.fetch("http://localhost:8080/SoilSensor").then(async (td) => {
+    WoT.consume(td).then((thing) => {
+        // read humidity and temperature sensor
+        thing.readProperty("humidity").then((h) => {
+            console.log("Humidity: " + h);
         });
-    } catch (err) {
-        console.error("Script error:", err);
-    }
+        thing.readProperty("temperature").then((t) => {
+            console.log("Temperature: " + t);
+        });
+        thing.subscribeEvent("tooDry",()=>{
+            // Activate a remote sprinkler
+        })
+    });
 }).catch((err) => { console.error("Fetch error:", err); });

--- a/material/explainer-code-sample/example-server.js
+++ b/material/explainer-code-sample/example-server.js
@@ -1,77 +1,62 @@
-Servient = require("@node-wot/core").Servient
-HttpServer = require("@node-wot/binding-http").HttpServer
 
-Helpers = require("@node-wot/core").Helpers
-
-// create Servient add HTTP binding
-let servient = new Servient();
-servient.addServer(new HttpServer());
-
-servient.start().then((WoT) => {
-	WoT.produce({
-		"@context": "https://www.w3.org/2019/wot/td/v1",
-		"id": "urn:dev:ops:Agriculture-1234",
-		"title": "Agriculture",
-		"base": "https://myagriculture.example.com/",
-		"securityDefinitions": {
-			"nosec_sc": {
-				"scheme": "nosec"
-			}
-		},
-		"security": ["nosec_sc"],
-		"properties": {
-			"temperature": {
-				"description": "Temperature in Celsius",
-				"type": "number",
-				"forms": [{
-					"href": "temperature"
-				}]
-			},
-			"humidity": {
-				"description": "Humidity in %",
-				"type": "number",
-				"forms": [{
-					"href": "humidity"
-				}]
-			}
-		},
-		"actions": {
-			"sprinkle": {
-				"description": "Turn on sprinkler system",
-				"data": {
-					"description": "Time in minutes",
-					"type": "integer"
-				},
-				"forms": [{
-					"href": "sprinkle"
-				}]
-			}
-		},
-		"events": {
-			"tooDry": {
-				"description": "Informs if it is too try",
-				"data": {
-					"type": "string"
-				},
-				"forms": [{
-					"href": "tooDry"
-				}]
-			}
+WoT.produce({
+	"@context": "https://www.w3.org/2019/wot/td/v1",
+	"id": "urn:dev:ops:Agriculture-1234",
+	"title": "SoilSensor",
+	"description": "A sample soil sensor used in agriculture",
+	"base": "https://myagriculture.example.com/",
+	"securityDefinitions": {
+		"nosec_sc": {
+			"scheme": "nosec"
 		}
-	}).then((thing) => {
-		console.log("Produced " + thing.getThingDescription().title);
-		thing.writeProperty("humidity", 0.45)
-		thing.writeProperty("temperature", 22.5)
+	},
+	"security": ["nosec_sc"],
+	"properties": {
+		"temperature": {
+			"description": "Temperature",
+			"type": "number",
+			"unit": "Celsius",
+			"forms": [{
+				"href": "temperature"
+			}]
+		},
+		"humidity": {
+			"description": "Humidity in %",
+			"type": "number",
+			"forms": [{
+				"href": "humidity"
+			}]
+		}
+	},
+	"events": {
+		"tooDry": {
+			"description": "Informs if the soil is too try",
+			"data": {
+				"type": "string"
+			},
+			"forms": [{
+				"href": "tooDry"
+			}]
+		}
+	}
+}).then((thing) => {
+	// The ExposedThing object is ready to be configured
 
-		thing.expose().then(() => {
-			console.info(thing.getThingDescription().title + " ready");
-			console.info("TD : " + JSON.stringify(thing.getThingDescription()));
-			thing.readProperty("humidity").then((c) => {
-				console.log("humidity is " + c);
-			});
-			thing.readProperty("temperature").then((c) => {
-				console.log("temperature is " + c);
-			});
+	// Initialize Thing properties
+	thing.writeProperty("humidity", 0.45)
+	thing.writeProperty("temperature", 22.5)
+
+	thing.expose().then(() => {
+		/*
+		* Web Thing SoilSensor is now ready and available at
+		* http://localhost:8080/SoilSensor
+		*/
+
+		thing.readProperty("humidity").then((c) => {
+			console.log("humidity is " + c);
+		});
+		thing.readProperty("temperature").then((c) => {
+			console.log("temperature is " + c);
 		});
 	});
 });

--- a/material/explainer-code-sample/td.jsonld
+++ b/material/explainer-code-sample/td.jsonld
@@ -1,7 +1,8 @@
 {
 	"@context": "https://www.w3.org/2019/wot/td/v1",
 	"id": "urn:dev:ops:Agriculture-1234",
-	"title": "Agriculture",
+	"title": "SoilSensor",
+	"description": "A sample soil sensor used in agriculture",
 	"base": "https://myagriculture.example.com/",
 	"securityDefinitions": {
 		"nosec_sc": {
@@ -11,8 +12,9 @@
 	"security": ["nosec_sc"],
 	"properties": {
 		"temperature": {
-			"description": "Temperature in Celsius",
+			"description": "Temperature",
 			"type": "number",
+			"unit": "Celsius",
 			"forms": [{
 				"href": "temperature"
 			}]
@@ -25,21 +27,9 @@
 			}]
 		}
 	},
-	"actions": {
-		"sprinkle": {
-			"description": "Turn on sprinkler system",
-			"data": {
-				"description": "Time in minutes",
-				"type": "integer"
-			},
-			"forms": [{
-				"href": "sprinkle"
-			}]
-		}
-	},
 	"events": {
 		"tooDry": {
-			"description": "Informs if it is too try",
+			"description": "Informs if the soil is too try",
 			"data": {
 				"type": "string"
 			},


### PR DESCRIPTION
I refactored the example code leveraging on `wot-servient`. In this way, the code is cleaner, shorter and I think easier to understand. 

Also, I modified the Thing Description to represent a possible soil sensor removing the sprinkler action. I thought it is easier to focus if the Thing does just one thing (pun intended). However, we could re-introduce the sprinkler as a second Web Thing and modify the client example accordingly. 

Finally, I also removed some console log, if the code is meant only to be shown I don't think that info messages are relevant. 