### PR TITLE
Add Use Case TF description

### DIFF
--- a/docs/activities/general/index.html
+++ b/docs/activities/general/index.html
@@ -16,8 +16,8 @@ group: "navigation"
 		<li><a href="/wot-marketing/activities/tf-discovery/">WoT Discovery</a></li>
 		<li><a href="/wot-marketing/activities/tf-security/">WoT Security</a></li>
 		<li><a href="/wot-marketing/activities/tf-scripting/">WoT Scripting API</a></li>
+		<li><a href="/wot-marketing/activities/tf-usecases/">WoT Use Cases</a></li>
 		<!-- <li>WoT Marketing</li>
-		<li>WoT Use Cases</li>
 		<li>WoT PoC</li>
 		<li>WoT PlugFest</li> -->
 	</ul>

--- a/docs/activities/tf-usecases/index.html
+++ b/docs/activities/tf-usecases/index.html
@@ -1,0 +1,49 @@
+---
+layout: default
+title: Use Case Task Force
+group: "navigation"
+---
+<div>
+<h2>W3C WoT – Use Case Task Force</h2>
+    <p>The WoT Use Case task force is responsible for 
+    collecting use cases for WoT and extracting requirements.
+    Use cases can include both specific vertical applications
+    and relevant technologies or other horizontal usage patterns.
+    Guests who are not WoT members but whom have an interest in 
+    specific vertical application domains, technologies, or usage patterns
+    are explictly invited to engage with this task force to provide input.
+    </p>
+    <div>
+    <h3>Informative Deliverables</h3>
+        <p>The WoT Use Case TF is working on the following informative deliverable.
+        </p>
+        <div>
+        <h4>WoT Use Cases and Requirements</h4>
+            <p>The WoT Use Cases and Requirements document includes a catalog and
+            taxonomy of use cases and a set of general requirements extracted
+            from an analysis of these use cases.  These requirements are then
+            used to drive the development of other normative WoT specifications.
+            </p>
+        </div>
+    </div>
+    <div>
+        <h3>People</h3>
+	<dl>
+        <dt>TF-Lead:</dt><dd>
+            Michael Lagally (Oracle Corp.)
+        </dd>
+        <dt>WoT Use Cases Co-Editors:</dt><dd>
+            Michael Lagally (Oracle Corp.),
+            Michael McCool (Intel Corp.),
+            Ryuichi Matsukura (Fujitsu Ltd.),
+            Tomoaki Mizushima (Internet Research Institute, Inc.)
+        </dd></dl>
+    </div>
+    <div>
+        <h3>Resources</h3>
+	<ul>
+        <li><a href="https://www.w3.org/WoT/IG/wiki/IG_UseCase_WebConf">WoT Use Cases TF Wiki (has meeting logistics)</a></li>
+        <li><a href="https://github.com/w3c/wot-usecases">WoT Use Cases github repository</a></li>
+	</ul>
+    </div>
+</div>


### PR DESCRIPTION
- Add description of WoT Use Case TF under activities 
    - question "Use Case" or "Use Cases"?  when used without "TF", "Use Case" sounds weird, when used WITH "TF" then "Use Case" sounds better as it is being used as an adjective.  I used both...)
- Add a link from the general page