### PR TITLE
Fix typos in Discovery TF description

### DIFF
--- a/docs/activities/tf-discovery/index.html
+++ b/docs/activities/tf-discovery/index.html
@@ -16,13 +16,13 @@ group: "navigation"
         </p>
         <div>
         <h4>WoT Discovery</h4>
-            <p>The WoT Discovery specfication defines a mechanism to provide
+            <p>The WoT Discovery specification defines a mechanism to provide
             access to WoT Thing Descriptions in both local and global contexts.
             It uses a two-phase approach to take advantage of existing discovery
             mechanisms for "first contact" but provides for authenticated web services
             to actually provide metadata in order to support security and privacy goals.
-            WoT Thing Descriptions can be retreived from services running either on
-            a Thing itself, supporting self-describing objects, or from a directory
+            WoT Thing Descriptions can be retrieved from services running either on
+            a Thing itself, directly from self-describing objects, or from a directory
             service that provides a searchable database of WoT Thing Descriptions.
             </p>
         </div>


### PR DESCRIPTION
Fix some spelling and grammar issues in the Discovery TF description.