### PR TITLE
add blog proposal for video

### DIFF
--- a/proposals/blogProposal.md
+++ b/proposals/blogProposal.md
@@ -1,8 +1,8 @@
-The Web of Things standardization activities are now illustrated through our new animation video that we have been working on for the last couple of months. You can see how any web developer can implement Internet of Things solutions while being interoperable and not locked into frameworks. Additionally, the W3C WoT allows the experience of the developers to be transferred to different application domains such as agriculture, building or industrial automation, smart home and more!
+The Web of Things standardization activities are now {illustrated|explained} through a new animation video that we have been working on for the last few months. You can see how any web developer can implement Internet of Things solutions while being interoperable and not locked into frameworks. Additionally, the W3C WoT allows the experience of the developers to be transferred to different application domains such as agriculture, building or industrial automation, smart home and more!
 
 -- To be decided
 
-We would like to thank the W3C Accessibility team for their feedback, as well as Siemens AG and Intel Inc. for the support and the team at WebCastor for quick iteration cycle to come up with our amazing video! 
+We would like to thank the W3C Web Accessibility Initiative team for their feedback, as well as Siemens AG and Intel Inc. for the support and the team at WebCastor for quick iteration cycles to come up with our amazing video! 
 
 [Insert Video Link/Thumbnail]
 

--- a/proposals/blogProposal.md
+++ b/proposals/blogProposal.md
@@ -5,3 +5,7 @@ The Web of Things standardization activities are now visible(?) through our new 
 We would like to thank the W3C Accessibility team for their feedback, as well as Siemens AG and Intel Inc. for the support and the team at WebCastor for quick iteration cycle to come up with our amazing video! 
 
 [Insert Video Link/Thumbnail]
+
+Also check our newly designed webpage that has all you need to know about the W3C WoT.
+
+[Insert webpage link, maybe a screenshot as thumbnail]

--- a/proposals/blogProposal.md
+++ b/proposals/blogProposal.md
@@ -1,0 +1,5 @@
+The Web of Things standardization activities are now visible(?) in our new animation video that we have been working on for the last couple of months. You can see how any web developer can implement Internet of Things solutions while being interoperable and not locked-in to framework. Additionally, the W3C WoT allows the experience of the developers to be transferred to different application domains such as agriculture, building or industrial automation, smart home or more!
+
+-- To be decided
+
+We would like to thank the W3C Accesibility team for their feedback, as well as Siemens AG and Intel Inc. for the support and the team at WebCastor for quick iteration cycle to come up with an amazing video!you

--- a/proposals/blogProposal.md
+++ b/proposals/blogProposal.md
@@ -1,4 +1,4 @@
-The Web of Things standardization activities are now visible(?) through our new animation video that we have been working on for the last couple of months. You can see how any web developer can implement Internet of Things solutions while being interoperable and not locked into frameworks. Additionally, the W3C WoT allows the experience of the developers to be transferred to different application domains such as agriculture, building or industrial automation, smart home and more!
+The Web of Things standardization activities are now illustrated through our new animation video that we have been working on for the last couple of months. You can see how any web developer can implement Internet of Things solutions while being interoperable and not locked into frameworks. Additionally, the W3C WoT allows the experience of the developers to be transferred to different application domains such as agriculture, building or industrial automation, smart home and more!
 
 -- To be decided
 

--- a/proposals/blogProposal.md
+++ b/proposals/blogProposal.md
@@ -1,8 +1,6 @@
-The Web of Things standardization activities are now {illustrated|explained} through a new animation video that we have been working on for the last few months. You can see how any web developer can implement Internet of Things solutions while being interoperable and not locked into frameworks. Additionally, the W3C WoT allows the experience of the developers to be transferred to different application domains such as agriculture, building or industrial automation, smart home and more!
+The Web of Things standardization activities are now illustrated through a new animation video that we have been working on for the last few months. You can see how a web developer can implement Internet of Things solutions while being interoperable and not locked into frameworks. Additionally, the W3C WoT allows the experience of the developers to be transferred to different application domains such as agriculture, building or industrial automation, smart home and more!
 
--- To be decided
-
-We would like to thank the W3C Web Accessibility Initiative team for their feedback, as well as Siemens AG and Intel Inc. for the support and the team at WebCastor for quick iteration cycles to come up with our amazing video! 
+We would like to thank the W3C Web Accessibility Initiative team for their feedback. 
 
 [Insert Video Link/Thumbnail]
 

--- a/proposals/blogProposal.md
+++ b/proposals/blogProposal.md
@@ -1,5 +1,7 @@
-The Web of Things standardization activities are now visible(?) in our new animation video that we have been working on for the last couple of months. You can see how any web developer can implement Internet of Things solutions while being interoperable and not locked-in to framework. Additionally, the W3C WoT allows the experience of the developers to be transferred to different application domains such as agriculture, building or industrial automation, smart home or more!
+The Web of Things standardization activities are now visible(?) through our new animation video that we have been working on for the last couple of months. You can see how any web developer can implement Internet of Things solutions while being interoperable and not locked into frameworks. Additionally, the W3C WoT allows the experience of the developers to be transferred to different application domains such as agriculture, building or industrial automation, smart home and more!
 
 -- To be decided
 
-We would like to thank the W3C Accesibility team for their feedback, as well as Siemens AG and Intel Inc. for the support and the team at WebCastor for quick iteration cycle to come up with an amazing video!you
+We would like to thank the W3C Accessibility team for their feedback, as well as Siemens AG and Intel Inc. for the support and the team at WebCastor for quick iteration cycle to come up with our amazing video! 
+
+[Insert Video Link/Thumbnail]


### PR DESCRIPTION
Here is the first version of the blog post proposal.

I am not sure about the last part, i.e. acknowledgment. It should be decided together I think. Also, there should be the video link/embed put in there but I am not sure how it is done in the W3C blog.

After putting in the blog, we should also tweet about it.