### PR TITLE
Fix typos in Use Case TF description

### DIFF
--- a/docs/activities/tf-usecases/index.html
+++ b/docs/activities/tf-usecases/index.html
@@ -9,9 +9,9 @@ group: "navigation"
     collecting use cases for WoT and extracting requirements.
     Use cases can include both specific vertical applications
     and relevant technologies or other horizontal usage patterns.
-    Guests who are not WoT members but whom have an interest in 
+    Guests who are not WoT members but who have an interest in 
     specific vertical application domains, technologies, or usage patterns
-    are explictly invited to engage with this task force to provide input.
+    are explicitly invited to engage with this task force to provide input.
     </p>
     <div>
     <h3>Informative Deliverables</h3>


### PR DESCRIPTION
Address typos noted by @mlagally in PR https://github.com/w3c/wot-marketing/pull/113