### PR TITLE
Web english review

### DIFF
--- a/docs/activities/tf-discovery/index.html
+++ b/docs/activities/tf-discovery/index.html
@@ -22,7 +22,7 @@ group: "navigation"
             mechanisms for "first contact" but provides for authenticated web services
             to actually provide metadata in order to support security and privacy goals.
             WoT Thing Descriptions can be retrieved from services running either on
-            a Thing itself, directly from self-describing objects, or from a directory
+            a Thing itself (that is, directly from self-describing objects), or from a directory
             service that provides a searchable database of WoT Thing Descriptions.
             </p>
         </div>

--- a/docs/activities/tf-scripting/index.html
+++ b/docs/activities/tf-scripting/index.html
@@ -8,8 +8,8 @@ group: "navigation"
     <p>
 		The WoT Scripting API task force is responsible for
 		specifying an application programming interface (API) representing
-		the WoT Interface that allows scripts to discover, operate Things
-		and expose locally defined Things characterized by WoT Interactions.
+		the WoT Interface that allows scripts to discover, invoke interactions with Things,
+		and expose interactions for locally defined Things.
     </p>
     <div>
 		<h3>Informative Deliverables</h3>
@@ -17,7 +17,7 @@ group: "navigation"
         </p>
         <div>
 			<h4>Web of Things (WoT) Scripting API</h4>
-            <p>Scripting is an optional building block in WoT and it is typically used in gateways or browsers that are able to run a WoT Runtime and script management, providing a convenient way to define the behavior of exposed Things, extend WoT support to new types of endpoints and implement WoT applications.
+            <p>Scripting is an optional building block in WoT and it is typically used in gateways, hubs, or browsers that are able to run a WoT Runtime and script management, providing a convenient way to define the behavior of exposed Things, extend WoT support to new types of endpoints, orchestrate interactions among multiple Things, and implement WoT applications.
             </p>
         </div>
     </div>

--- a/docs/activities/tf-security/index.html
+++ b/docs/activities/tf-security/index.html
@@ -14,14 +14,15 @@ group: "navigation"
     <h3>Informative Deliverables</h3>
         <p>In addition to contributions to other normative and informative WoT deliverables, 
         such as security features
-        in the WoT Thing Description, the WoT Security TF has its own informative deliverables.
+        in the WoT Thing Description and in WoT Discovery, 
+        the WoT Security TF has its own informative deliverables.
         </p>
         <div>
         <h4>WoT Security and Privacy Guidelines</h4>
             <p>The WoT Security and Privacy Guidelines document defines general 
             security and privacy concepts and terminology
             for the W3C Web of Things, catalogs stakeholders and threats, and provides general
-            guidance in order to mitigate these threats.
+            guidance on best practices to mitigate these threats.
             </p>
         </div>
     </div>

--- a/docs/activities/tf-td/index.html
+++ b/docs/activities/tf-td/index.html
@@ -6,29 +6,35 @@ group: "navigation"
 <div>
 	<h2>W3C WoT – Thing Description Task Force</h2>
 		<p>The WoT Thing Description task force is responsible for 
-		defining the information model for the Things, its interpretation and
+		defining the information model for WoT Thing metadata, its interpretation, and its
 		common representation. In addition, the task force covers WoT Binding Templates 
-		topics to define the mapping to concrete IoT protocols and payload encodings.		
+		topics to define the mapping from the abstract interaction model
+                used in the Thing Description metadata to concrete IoT protocols and payload encodings.		
 		</p>
 		<div>
 		<h3>Normative Deliverable</h3>
  			<div>
 			<h4>WoT Thing Description 1.1</h4>
-				<p>This specification describes a superset of the features defined in Thing Description 1.0.
-					In general, the specification describes the formal model of a Thing and its common representation in JSON-LD 1.1. 
-					It introduces a simple interaction model with Properties, Actions, and Events
-				   to describe the capabilities of the Thing, including its data model, the communication protocol used, security mode, 
-				   and other semantic metadata. The WoT Thing Description 1.1 also formally introduces the Thing Model concept that has less 
-				   restriction and does not contain any instance-specific information.
+				<p>This document describes a superset of the features defined for Thing Description 1.0.
+				In general, this document describes the formal model of a Thing and its common representation in JSON-LD 1.1. 
+				It introduces a simple interaction model with Properties, Actions, and Events
+				to describe the capabilities of a Thing, including its data model, 
+                                communication protocols used, security mechanisms, 
+				and other semantic metadata. 
+                                A WoT Thing Description defines a specific instance of a Thing.
+                                The WoT Thing Description 1.1 also formally introduces the Thing Model concept that 
+                                describes sets of Things.
+                                It has fewer restrictions than the Thing Description
+                                and does not contain any instance-specific information.
 				</p>
 			</div>
 			<h3>Informative Deliverable</h3>
 			<div>
 				<h4>WoT Binding Templates</h4>
-				<p>This document describes the set of vocabulary extensions to 
+				<p>This document describes a set of vocabulary extensions to 
 				the WoT Thing Description that make up the Binding Templates. Binding 
-				Templates enable a Thing Description to be adapted to the specific protocol 
-				or data payload usage across the different standards. This is done through additional 
+				Templates enable a Thing Description to be adapted to specific protocol 
+				or data payload usages across different standards. This is done through additional 
 				descriptive vocabulary that is used in the Thing Description. 
 				</p>
         	</div>

--- a/docs/activities/tf-usecases/index.html
+++ b/docs/activities/tf-usecases/index.html
@@ -8,7 +8,7 @@ group: "navigation"
     <p>The WoT Use Case task force is responsible for 
     collecting use cases for WoT and extracting requirements.
     Use cases can include both specific vertical applications
-    and relevant technologies or other horizontal usage patterns.
+    as well as relevant horizontal technologies or other horizontal usage patterns.
     Guests who are not WoT members but who have an interest in 
     specific vertical application domains, technologies, or usage patterns
     are explicitly invited to engage with this task force to provide input.

--- a/docs/cg/index.html
+++ b/docs/cg/index.html
@@ -5,7 +5,7 @@ group: "navigation"
 ---
 <div>
 	<h2>W3C WoT – Community Groups</h2>
-	<p>There are the following two Community Groups:</p>
+	<p>The following two Community Groups support WoT activities:</p>
 	<ul>
 		<li>Web of Things Community Group</li>
 		<li>Web of Things Japanese Community Group</li>
@@ -15,6 +15,8 @@ group: "navigation"
 	<p>
 		The aim of the Web of Things Community Group (CG) is to accelerate the adoption of Web technologies as a basis for enabling services for the combination of the Internet of Things with rich descriptions of things and the context in which they are used.
 	</p>
+        <p>This group will not publish any specifications.</p>
+
 	<p>Chair: <a href="#">Dave Raggett</a></p>
 	
 	<p>&nbsp;</p>
@@ -42,11 +44,12 @@ group: "navigation"
 	<h3>Web of Things Japanese Community Group</h3>
 	<p>The mission of the Web of Things Japanese Community Group includes the following:</p>
 	<ul>
-		<li>to facilitate focused discussion in Japanese on the Web of Things specifications and related specifications</li>
-		<li>to gather comments and questions in Japanese about those specifications</li>
-		<li>to collect information about specific use cases in Japanese for technologies defined in those specifications</li>
-		<li>to report the results of its activities as a group back to the Web of Things Working Group/Interest Group, the W3C membership and the Web community This group will not publish any specifications.</li>
+		<li>to facilitate focused discussion in Japanese on the Web of Things specifications and related specifications;</li>
+		<li>to gather comments and questions in Japanese about those specifications;</li>
+		<li>to collect information about specific use cases in Japanese for technologies defined in those specifications; and</li>
+		<li>to report the results of its activities as a group back to the Web of Things Working Group/Interest Group, the W3C membership, and the Web community.</li>
 	</ul>
+        <p>This group will not publish any specifications.</p>
 	
 	<p>Chair: Tomoaki Mizushima (IRI), Kunihiko Toumura (Hitachi)</p>
 	

--- a/docs/developers/index.html
+++ b/docs/developers/index.html
@@ -5,7 +5,7 @@ group: "navigation"
 ---
 <div>
 	<h2>Developer Tools</h2>
-	<p>Please find below a list of tools that may be useful in Web of Things (WoT) context.</p>
+	<p>The following tools that may be useful in the Web of Things (WoT) context.</p>
 	<!-- <p>...<mark>TODO Description etc.. </mark></p> -->
 	
 	<h3>Thing Description (TD) Tooling</h3>
@@ -25,7 +25,7 @@ group: "navigation"
 		<li><a href="https://marketplace.visualstudio.com/items?itemName=arces-wot.td-code">TD code</a>
 			(TD validation and code snippets for Visual Studio Code)
 			<ul>
-				<li>See short presentation about TD Code used together with <a
+				<li>See a short presentation about TD Code used together with the <a
 						href="https://github.com/UniBO-PRISMLab/wam">WoT Application Manager (WAM)</a>: <a
 						href="WoT%20Application%20Manager.pdf" target="_blank">slides</a> or <a href="https://youtu.be/bPxIfZo7jns">video</a></li>
 			</ul>
@@ -56,14 +56,14 @@ group: "navigation"
 		<li>
 			<a href="https://github.com/node-red/node-red-nodegen">Node generator</a> (Generate a WoT Consumer Node for <a href="https://nodered.org/">Node-RED</a> from TD)
 			<ul>
-				<li>See short introduction <a href="wot_nodegen.pptx" target="_blank">slides</a> or <a href="wot_nodegen.mp4" target="_blank">video</a> for Node Generator</li>
+				<li>See a short introduction <a href="wot_nodegen.pptx" target="_blank">slides</a> or <a href="wot_nodegen.mp4" target="_blank">video</a> for Node Generator</li>
 			</ul>
 		</li>
 	</ul>
 	<h3>WoT application development tools</h3>
 	<ul>
 		<li><a href="https://github.com/UniBO-PRISMLab/wam">WoT Application Manager (WAM)</a>
-			cli tool to set up node-wot application projects. See the presentation and video for further information: <a
+			CLI tool to set up node-wot application projects. See the presentation and video for further information: <a
 				href="WoT%20Application%20Manager.pdf" target="_blank">slides</a> or <a href="https://youtu.be/bPxIfZo7jns">video</a>
 		</li>
 	</ul>

--- a/docs/documentation/index.html
+++ b/docs/documentation/index.html
@@ -10,7 +10,7 @@ group: "navigation"
 		<li><a href="#web-of-things-in-a-nutshell">Web of Things in a Nutshell</a></li>
 		<li><a href="#wot-interactions">WoT Interactions</a></li>
 		<li><a href="#wot-building-blocks">WoT Building Blocks</a></li>
-		<li><a href="#links">Links</a></li>
+		<li><a href="#further-reading">Further Reading</a></li>
 	</ul>
     <div class="row">
         <p>&nbsp;</p>
@@ -150,11 +150,11 @@ group: "navigation"
         <div class="col-md-12">
             <p>
             The (optional) <strong>WoT Scripting API</strong> building block 
-            defines an ECMAScript API that closely follows the WoT Thing Description 
+            defines an ECMAScript (JavaScript) API that closely follows the WoT Thing Description 
             specification and supports the WoT interaction abstraction. 
             It defines the interface between behavior implementations and a 
             scripting-based WoT runtime. 
-            Please note however that implementation of WoT are not limited to 
+            Please note however that implementations of WoT are not limited to 
             scripting environments. 
             Programming language APIs in Java or C/C++ can also be derived from 
             the WoT Scripting API. 
@@ -170,7 +170,7 @@ group: "navigation"
         <div class="col-md-12">
             <p>
             The Web of Things also provides guidance on <strong>WoT Security and Privacy</strong>. 
-            Security is a cross-cutting building block which provides guidelines for the secure 
+            WoT provides guidelines for the secure 
             implementation and configuration of Things. 
             Security and privacy 
             should be considered in any system implementing W3C WoT.
@@ -185,12 +185,12 @@ group: "navigation"
     <div class="row">
         <p>&nbsp;</p>
     </div>
-	<h3 id="links">Links</h3>
+	<h3 id="further-reading">Further Reading</h3>
     <div class="row">
         <div class="col-md-12">
             <p>
-                For further reading, please find below a set of links to a variety of materials 
-                including presentations, and documents.
+                For further reading, please find below a set of links to a variety of additional material 
+                including presentations and documents.
             </p>
 			<h4>WoT Publications</h4>
 			<ul>

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,10 +7,10 @@ title: Home
 	<div class="col-md-8">
 	<h2>W3C Web of Things</h2>
 	<p>
-		The Web of Things (WoT) seeks to counter the fragmentation of the IoT by using and extending existing, standardized Web technologies. Providing metadata and re-usable technological building blocks, W3C WoT enables easy integration across IoT platforms and application domains.
+		The Web of Things (WoT) seeks to counter the fragmentation of the IoT by using and extending existing, standardized Web technologies. By providing standardized metadata and other re-usable technological building blocks, W3C WoT enables easy integration across IoT platforms and application domains.
 	</p>
 	<p>
-		Get more background about Web of Things in the <a href="documentation/">Documentation</a> area.
+		Get more background about the Web of Things in the <a href="documentation/">Documentation</a> area.
 	</p>
 	</div>
 	<div class="col-md-4">


### PR DESCRIPTION
Review entire site looking for english fixes.
Some minor tweaks here and there.  Please review the opening paragraph.
In some cases my changes went beyond English, i.e. I noticed the use of "gateway" in the description of Scripting and based on recent discussion added "hub", and also added "orchestration" to the set of applications for scripting.
One thing I did not change was the description of the WoT CG since it seemed copied from the charter, but I also felt it was very long, verbose, and confusing, so at some point we should review it and probably update it.  I also cleaned up a "This group does not publish specifications" note under the CGs (for the Japanese CG it was mixed into the list in an odd way).