### PR TITLE
Webpage: Adding TF info to WG and IG overview pages

### DIFF
--- a/docs/ig/index.html
+++ b/docs/ig/index.html
@@ -11,17 +11,19 @@ group: "navigation"
 	<p>Co-Chairs: <a href="mailto:michael.mccool@intel.com">Michael McCool (Intel)</a> and <a href="mailto:sebastian.kaebisch@siemens.com">Sebastian K&auml;bisch (Siemens)</a></p>
 	<p>Team contacts: <a href="https://www.w3.org/People#ashimura">Kazuyuki Ashimura</a> and <a href="https://www.w3.org/People#dsr">Dave Raggett</a></p>
 
+	<p>&nbsp;</p>
+
 	<h3>Task Forces</h3>
 	<p>
 		The Web of Things (WoT) Interest Group (IG) conducts some of its work via the following task forces.<br />
 		See each task force page for details about specific work.
 	</p>
-
-	<table>
+	
+	<table style="width: 100%">	
 		<tr>
-			<th>Name</th>
-			<th>Deliverable</th>
-			<th>Taskforce Lead</th>
+			<th style="text-align:left">Name</th>
+			<th style="text-align:left">Deliverable</th>
+			<th style="text-align:left">Taskforce Lead</th>
 		</tr>
 		<tr>
 			<td><a href="{{'activities/tf-usecases/' | relative_url }}">WoT Use Cases</a></td>

--- a/docs/ig/index.html
+++ b/docs/ig/index.html
@@ -10,7 +10,40 @@ group: "navigation"
 	</p>
 	<p>Co-Chairs: <a href="mailto:michael.mccool@intel.com">Michael McCool (Intel)</a> and <a href="mailto:sebastian.kaebisch@siemens.com">Sebastian K&auml;bisch (Siemens)</a></p>
 	<p>Team contacts: <a href="https://www.w3.org/People#ashimura">Kazuyuki Ashimura</a> and <a href="https://www.w3.org/People#dsr">Dave Raggett</a></p>
-	
+
+	<h3>Task Forces</h3>
+	<p>
+		The Web of Things (WoT) Interest Group (IG) conducts some of its work via the following task forces.<br />
+		See each task force page for details about specific work.
+	</p>
+
+	<table>
+		<tr>
+			<th>Name</th>
+			<th>Deliverable</th>
+			<th>Taskforce Lead</th>
+		</tr>
+		<tr>
+			<td><a href="{{'activities/tf-usecases/' | relative_url }}">WoT Use Cases</a></td>
+			<td>WoT Use Cases
+			<td><a href="mailto:michael.lagally@oracle.com">Michael Lagally (Oracle Corp.)</a></td>
+		</tr>
+		<tr>
+			<td><a href="{{'activities/tf-marketing/' | relative_url }}">WoT Marketing</a></td>
+			<td>WoT Wiki Page, Collateral
+			<td><a href="mailto:sebastian.kaebisch@siemens.com">Sebastian K&auml;bisch (Siemens)</a></td>
+		</tr>
+		<tr>
+			<td><a href="{{'activities/tf-poc/' | relative_url }}">WoT PoC</a></td>
+			<td> WoT PoC</td>
+			<td><a href="mailto:michael.mccool@intel.com">Michael McCool (Intel)</a></td>
+		</tr>
+		<tr>
+			<td><a href="{{'activities/tf-plugfest/' | relative_url }}">WoT Plugfest</a></td>
+			<td> WoT Plugfest</td>
+			<td><a href="mailto:michael.mccool@intel.com">Michael McCool (Intel)</a></td>
+	</table>
+
 	<p>&nbsp;</p>
 	
 	<div class="row center-block">
@@ -21,9 +54,9 @@ group: "navigation"
 			<a href="https://lists.w3.org/Archives/Public/public-wot-ig/"><div class="icon"><img src="https://image.flaticon.com/icons/svg/131/131155.svg" alt="" width="45"></div><div class="description"><h3>Mailing List</h3><p>Public mailing list archive and sign-up.</p></div></a>
 		</div>
 	</div>
-	
+
 	<p>&nbsp;</p>
-	
+
 	<div class="row center-block">
 		<div class="col-md-6 text-center">
 			<a href="https://www.w3.org/groups/ig/wot"><div class="icon"><img src="https://image.flaticon.com/icons/svg/476/476700.svg" alt="" width="45"></div><div class="description"><h3>Participants</h3><p>List of people and<br/>organizations participating.</p></div></a>

--- a/docs/wg/index.html
+++ b/docs/wg/index.html
@@ -6,13 +6,52 @@ group: "navigation"
 <div>
 	<h2>W3C WoT – Working Group</h2>
 	<p>
-		The W3C WoT Working Group (WG) is tasked to write standards-track specifications and test suites. To ensure royalty-free Web standards, participants must be W3C and WoT WG Members and acknowledge the <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/">W3C Patent Policy</a>.
+		The W3C WoT Working Group (WG) is tasked to create standards-track specifications and test suites. To ensure royalty-free Web standards, participants must be W3C and WoT WG Members and acknowledge the <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/">W3C Patent Policy</a>.
 	</p>
 	<p>Co-Chairs: <a href="mailto:michael.mccool@intel.com">Michael McCool (Intel)</a> and <a href="mailto:sebastian.kaebisch@siemens.com">Sebastian K&auml;bisch (Siemens)</a></p>
 	<p>Team contacts: <a href="https://www.w3.org/People#ashimura">Kazuyuki Ashimura</a> and <a href="https://www.w3.org/People#dsr">Dave Raggett</a></p>
 	
 	<p>&nbsp;</p>
-	
+	<h3>Task Forces</h3>
+	<p>
+		The Web of Things (WoT) Working Group (WG) conducts some of its work via the following task forces.<br />
+		See each task force page for details about specific work.
+	</p>
+	<table>
+		<tr>
+			<th>Name</th>
+			<th>Deliverable</th>
+			<th>Taskforce Lead</th>
+		</tr>
+		<tr>
+			<td><a href="{{'activities/tf-architecture/' | relative_url }}">WoT Architecture</a></td>
+			<td>WoT Architecture<br>WoT Profile</td>
+			<td><a href="mailto:michael.lagally@oracle.com">Michael Lagally (Oracle Corp.)</a></td>
+		</tr>
+		<tr>
+			<td><a href="{{'activities/tf-td/' | relative_url }}">WoT Thing Description</a></td>
+			<td>WoT Thing Description<br>WoT Binding Templates</td>
+			<td><a href="mailto:sebastian.kaebisch@siemens.com">Sebastian K&auml;bisch (Siemens)</a><br></td>
+		</tr>
+		<tr>
+			<td><a href="{{'activities/tf-discovery/' | relative_url }}">WoT Discovery</a></td>
+			<td>WoT Discovery</td>
+			<td><a href="mailto:michael.mccool@intel.com">Michael McCool (Intel)</a></td>
+		</tr>
+		<tr>
+			<td><a href="{{'activities/tf-security/' | relative_url }}">WoT Security</a></td>
+			<td>WoT Security</td>
+			<td><a href="mailto:michael.mccool@intel.com">Michael McCool (Intel)</a></td>
+		</tr>
+		<tr>
+			<td><a href="{{'activities/tf-scripting/' | relative_url }}">WoT Scripting API</a></td>
+			<td>WoT Scripting</td>
+			<td><a href="mailto:daniel.peintner.ext@siemens.com">Daniel Peintner (Siemens AG)</a></td>
+		</tr>
+	</table>
+
+	<p>&nbsp;</p>
+
 	<div class="row center-block">
 		<div class="col-md-6 text-center">
 			<a href="https://www.w3.org/2020/01/wot-wg-charter.html"><div class="icon"><img src="https://image.flaticon.com/icons/svg/149/149345.svg" alt="" width="45"></div><div class="description"><h3>WG Charter</h3><p>Active from 31 January 2020<br/>until 31 January 2022.</p></div></a>

--- a/docs/wg/index.html
+++ b/docs/wg/index.html
@@ -17,7 +17,9 @@ group: "navigation"
 		The Web of Things (WoT) Working Group (WG) conducts some of its work via the following task forces.<br />
 		See each task force page for details about specific work.
 	</p>
-	<table>
+	<table {
+			width: 100%;
+		}>
 		<tr>
 			<th>Name</th>
 			<th>Deliverable</th>


### PR DESCRIPTION
This change simplifies navigation and gives credit to TF leads.