### PR TITLE
Fixes Issue 153

### DIFF
--- a/docs/ig/index.html
+++ b/docs/ig/index.html
@@ -10,6 +10,28 @@ group: "navigation"
 	</p>
 	<p>Co-Chairs: <a href="mailto:michael.mccool@intel.com">Michael McCool (Intel)</a> and <a href="mailto:sebastian.kaebisch@siemens.com">Sebastian K&auml;bisch (Siemens)</a></p>
 	<p>Team contacts: <a href="https://www.w3.org/People#ashimura">Kazuyuki Ashimura</a> and <a href="https://www.w3.org/People#dsr">Dave Raggett</a></p>
+	
+	<p>&nbsp;</p>
+	
+	<div class="row center-block">
+		<div class="col-md-6 text-center">
+			<a href="https://www.w3.org/2019/10/wot-ig-2019.html"><div class="icon"><img src="https://image.flaticon.com/icons/svg/149/149345.svg" alt="" width="45"></div><div class="description"><h3>IG Charter</h3><p>Active from 22 October 2019<br/>until 30 June 2021 .</p></div></a>
+		</div>
+		<div class="col-md-6 text-center">
+			<a href="https://lists.w3.org/Archives/Public/public-wot-ig/"><div class="icon"><img src="https://image.flaticon.com/icons/svg/131/131155.svg" alt="" width="45"></div><div class="description"><h3>Mailing List</h3><p>Public mailing list archive and sign-up.</p></div></a>
+		</div>
+	</div>
+
+	<p>&nbsp;</p>
+
+	<div class="row center-block">
+		<div class="col-md-6 text-center">
+			<a href="https://www.w3.org/groups/ig/wot"><div class="icon"><img src="https://image.flaticon.com/icons/svg/476/476700.svg" alt="" width="45"></div><div class="description"><h3>Participants</h3><p>List of people and<br/>organizations participating.</p></div></a>
+		</div>
+		<div class="col-md-6 text-center">
+			<a href="https://www.w3.org/2004/01/pp-impl/75874/instructions"><div class="icon"><img src="https://image.flaticon.com/icons/svg/149/149387.svg" alt="" width="45"></div><div class="description"><h3>Join</h3><p>Learn how to become<br/>an IG participant.</p></div></a>
+		</div>
+	</div>
 
 	<p>&nbsp;</p>
 
@@ -47,28 +69,6 @@ group: "navigation"
 					<td> WoT Plugfest</td>
 					<td><a href="mailto:michael.mccool@intel.com">Michael McCool (Intel)</a></td>
 			</table>
-		</div>
-	</div>
-
-	<p>&nbsp;</p>
-	
-	<div class="row center-block">
-		<div class="col-md-6 text-center">
-			<a href="https://www.w3.org/2019/10/wot-ig-2019.html"><div class="icon"><img src="https://image.flaticon.com/icons/svg/149/149345.svg" alt="" width="45"></div><div class="description"><h3>IG Charter</h3><p>Active from 22 October 2019<br/>until 30 June 2021 .</p></div></a>
-		</div>
-		<div class="col-md-6 text-center">
-			<a href="https://lists.w3.org/Archives/Public/public-wot-ig/"><div class="icon"><img src="https://image.flaticon.com/icons/svg/131/131155.svg" alt="" width="45"></div><div class="description"><h3>Mailing List</h3><p>Public mailing list archive and sign-up.</p></div></a>
-		</div>
-	</div>
-
-	<p>&nbsp;</p>
-
-	<div class="row center-block">
-		<div class="col-md-6 text-center">
-			<a href="https://www.w3.org/groups/ig/wot"><div class="icon"><img src="https://image.flaticon.com/icons/svg/476/476700.svg" alt="" width="45"></div><div class="description"><h3>Participants</h3><p>List of people and<br/>organizations participating.</p></div></a>
-		</div>
-		<div class="col-md-6 text-center">
-			<a href="https://www.w3.org/2004/01/pp-impl/75874/instructions"><div class="icon"><img src="https://image.flaticon.com/icons/svg/149/149387.svg" alt="" width="45"></div><div class="description"><h3>Join</h3><p>Learn how to become<br/>an IG participant.</p></div></a>
 		</div>
 	</div>
 	

--- a/docs/ig/index.html
+++ b/docs/ig/index.html
@@ -47,7 +47,7 @@ group: "navigation"
 				<tr>
 					<th style="text-align:left">Name</th>
 					<th style="text-align:left">Deliverable</th>
-					<th style="text-align:left">Taskforce Lead</th>
+					<th style="text-align:left">Task Force Lead</th>
 				</tr>
 				<tr>
 					<td><a href="{{'activities/tf-usecases/' | relative_url }}">WoT Use Cases</a></td>

--- a/docs/ig/index.html
+++ b/docs/ig/index.html
@@ -51,22 +51,22 @@ group: "navigation"
 				</tr>
 				<tr>
 					<td><a href="{{'activities/tf-usecases/' | relative_url }}">WoT Use Cases</a></td>
-					<td style="text-align:right;">WoT Use Cases
+					<td style="text-align:center;">WoT Use Cases
 					<td style="text-align:right;"><a href="mailto:michael.lagally@oracle.com">Michael Lagally (Oracle Corp.)</a></td>
 				</tr>
 				<tr>
 					<td><a href="{{'activities/tf-marketing/' | relative_url }}">WoT Marketing</a></td>
-					<td style="text-align:right;">WoT Wiki Page, Collateral
+					<td style="text-align:center;">WoT Wiki Page, Collateral
 					<td style="text-align:right;"><a href="mailto:sebastian.kaebisch@siemens.com">Sebastian K&auml;bisch (Siemens)</a></td>
 				</tr>
 				<tr>
 					<td><a href="{{'activities/tf-poc/' | relative_url }}">WoT PoC</a></td>
-					<td style="text-align:right;">WoT PoC</td>
+					<td style="text-align:center;">WoT PoC</td>
 					<td style="text-align:right;"><a href="mailto:michael.mccool@intel.com">Michael McCool (Intel)</a></td>
 				</tr>
 				<tr>
 					<td><a href="{{'activities/tf-plugfest/' | relative_url }}">WoT Plugfest</a></td>
-					<td style="text-align:right;">WoT Plugfest</td>
+					<td style="text-align:center;">WoT Plugfest</td>
 					<td style="text-align:right;"><a href="mailto:michael.mccool@intel.com">Michael McCool (Intel)</a></td>
 			</table>
 		</div>

--- a/docs/ig/index.html
+++ b/docs/ig/index.html
@@ -45,29 +45,29 @@ group: "navigation"
 		<div class="col-md-12">
 			<table style="width: 100%">	
 				<tr>
-					<th style="text-align:left">Name</th>
-					<th style="text-align:left">Deliverable</th>
-					<th style="text-align:left">Task Force Lead</th>
+					<th>Name</th>
+					<th style="text-align:center">Deliverable</th>
+					<th style="text-align:right">Task Force Lead</th>
 				</tr>
 				<tr>
 					<td><a href="{{'activities/tf-usecases/' | relative_url }}">WoT Use Cases</a></td>
-					<td>WoT Use Cases
-					<td><a href="mailto:michael.lagally@oracle.com">Michael Lagally (Oracle Corp.)</a></td>
+					<td style="text-align:right;">WoT Use Cases
+					<td style="text-align:right;"><a href="mailto:michael.lagally@oracle.com">Michael Lagally (Oracle Corp.)</a></td>
 				</tr>
 				<tr>
 					<td><a href="{{'activities/tf-marketing/' | relative_url }}">WoT Marketing</a></td>
-					<td>WoT Wiki Page, Collateral
-					<td><a href="mailto:sebastian.kaebisch@siemens.com">Sebastian K&auml;bisch (Siemens)</a></td>
+					<td style="text-align:right;">WoT Wiki Page, Collateral
+					<td style="text-align:right;"><a href="mailto:sebastian.kaebisch@siemens.com">Sebastian K&auml;bisch (Siemens)</a></td>
 				</tr>
 				<tr>
 					<td><a href="{{'activities/tf-poc/' | relative_url }}">WoT PoC</a></td>
-					<td> WoT PoC</td>
-					<td><a href="mailto:michael.mccool@intel.com">Michael McCool (Intel)</a></td>
+					<td style="text-align:right;">WoT PoC</td>
+					<td style="text-align:right;"><a href="mailto:michael.mccool@intel.com">Michael McCool (Intel)</a></td>
 				</tr>
 				<tr>
 					<td><a href="{{'activities/tf-plugfest/' | relative_url }}">WoT Plugfest</a></td>
-					<td> WoT Plugfest</td>
-					<td><a href="mailto:michael.mccool@intel.com">Michael McCool (Intel)</a></td>
+					<td style="text-align:right;">WoT Plugfest</td>
+					<td style="text-align:right;"><a href="mailto:michael.mccool@intel.com">Michael McCool (Intel)</a></td>
 			</table>
 		</div>
 	</div>

--- a/docs/wg/index.html
+++ b/docs/wg/index.html
@@ -45,7 +45,7 @@ group: "navigation"
 				<tr>
 					<th>Name</th>
 					<th>Deliverable</th>
-					<th>Taskforce Lead</th>
+					<th>Task Force Lead</th>
 				</tr>
 				<tr>
 					<td><a href="{{'activities/tf-architecture/' | relative_url }}">WoT Architecture</a></td>

--- a/docs/wg/index.html
+++ b/docs/wg/index.html
@@ -49,27 +49,27 @@ group: "navigation"
 				</tr>
 				<tr>
 					<td><a href="{{'activities/tf-architecture/' | relative_url }}">WoT Architecture</a></td>
-					<td style="text-align:right;">WoT Architecture<br>WoT Profile</td>
+					<td style="text-align:center;">WoT Architecture<br>WoT Profile</td>
 					<td style="text-align:right;"><a href="mailto:michael.lagally@oracle.com">Michael Lagally (Oracle Corp.)</a></td>
 				</tr>
 				<tr>
 					<td><a href="{{'activities/tf-td/' | relative_url }}">WoT Thing Description</a></td>
-					<td style="text-align:right;">WoT Thing Description<br>WoT Binding Templates</td>
+					<td style="text-align:center;">WoT Thing Description<br>WoT Binding Templates</td>
 					<td style="text-align:right;"><a href="mailto:sebastian.kaebisch@siemens.com">Sebastian K&auml;bisch (Siemens)</a><br></td>
 				</tr>
 				<tr>
 					<td><a href="{{'activities/tf-discovery/' | relative_url }}">WoT Discovery</a></td>
-					<td style="text-align:right;">WoT Discovery</td>
+					<td style="text-align:center;">WoT Discovery</td>
 					<td style="text-align:right;"><a href="mailto:michael.mccool@intel.com">Michael McCool (Intel)</a></td>
 				</tr>
 				<tr>
 					<td><a href="{{'activities/tf-security/' | relative_url }}">WoT Security</a></td>
-					<td style="text-align:right;">WoT Security</td>
+					<td style="text-align:center;">WoT Security</td>
 					<td style="text-align:right;"><a href="mailto:michael.mccool@intel.com">Michael McCool (Intel)</a></td>
 				</tr>
 				<tr>
 					<td><a href="{{'activities/tf-scripting/' | relative_url }}">WoT Scripting API</a></td>
-					<td style="text-align:right;">WoT Scripting</td>
+					<td style="text-align:center;">WoT Scripting</td>
 					<td style="text-align:right;"><a href="mailto:daniel.peintner.ext@siemens.com">Daniel Peintner (Siemens AG)</a></td>
 				</tr>
 			</table>

--- a/docs/wg/index.html
+++ b/docs/wg/index.html
@@ -12,6 +12,28 @@ group: "navigation"
 	<p>Team contacts: <a href="https://www.w3.org/People#ashimura">Kazuyuki Ashimura</a> and <a href="https://www.w3.org/People#dsr">Dave Raggett</a></p>
 	
 	<p>&nbsp;</p>
+
+	<div class="row center-block">
+		<div class="col-md-6 text-center">
+			<a href="https://www.w3.org/2020/01/wot-wg-charter.html"><div class="icon"><img src="https://image.flaticon.com/icons/svg/149/149345.svg" alt="" width="45"></div><div class="description"><h3>WG Charter</h3><p>Active from 31 January 2020<br/>until 31 January 2022.</p></div></a>
+		</div>
+		<div class="col-md-6 text-center">
+			<a href="https://lists.w3.org/Archives/Member/member-wot-wg/"><div class="icon"><img src="https://image.flaticon.com/icons/svg/131/131155.svg" alt="" width="45"></div><div class="description"><h3>Mailing List</h3><p>Member mailing list archive.</p></div></a>
+		</div>
+	</div>
+	
+	<p>&nbsp;</p>
+	
+	<div class="row center-block">
+		<div class="col-md-6 text-center">
+			<a href="https://www.w3.org/groups/wg/wot"><div class="icon"><img src="https://image.flaticon.com/icons/svg/476/476700.svg" alt="" width="45"></div><div class="description"><h3>Participants</h3><p>List of people and<br/>organizations participating.</p></div></a>
+		</div>
+		<div class="col-md-6 text-center">
+			<a href="https://www.w3.org/2004/01/pp-impl/95969/instructions"><div class="icon"><img src="https://image.flaticon.com/icons/svg/149/149387.svg" alt="" width="45"></div><div class="description"><h3>Join</h3><p>Learn how to become<br/>a WG participant.</p></div></a>
+		</div>
+	</div>
+	
+	<p>&nbsp;</p>
 	<h3>Task Forces</h3>
 	<p>
 		The Web of Things (WoT) Working Group (WG) conducts some of its work via the following task forces.<br />
@@ -51,27 +73,6 @@ group: "navigation"
 					<td><a href="mailto:daniel.peintner.ext@siemens.com">Daniel Peintner (Siemens AG)</a></td>
 				</tr>
 			</table>
-		</div>
-	</div>
-	<p>&nbsp;</p>
-
-	<div class="row center-block">
-		<div class="col-md-6 text-center">
-			<a href="https://www.w3.org/2020/01/wot-wg-charter.html"><div class="icon"><img src="https://image.flaticon.com/icons/svg/149/149345.svg" alt="" width="45"></div><div class="description"><h3>WG Charter</h3><p>Active from 31 January 2020<br/>until 31 January 2022.</p></div></a>
-		</div>
-		<div class="col-md-6 text-center">
-			<a href="https://lists.w3.org/Archives/Member/member-wot-wg/"><div class="icon"><img src="https://image.flaticon.com/icons/svg/131/131155.svg" alt="" width="45"></div><div class="description"><h3>Mailing List</h3><p>Member mailing list archive.</p></div></a>
-		</div>
-	</div>
-	
-	<p>&nbsp;</p>
-	
-	<div class="row center-block">
-		<div class="col-md-6 text-center">
-			<a href="https://www.w3.org/groups/wg/wot"><div class="icon"><img src="https://image.flaticon.com/icons/svg/476/476700.svg" alt="" width="45"></div><div class="description"><h3>Participants</h3><p>List of people and<br/>organizations participating.</p></div></a>
-		</div>
-		<div class="col-md-6 text-center">
-			<a href="https://www.w3.org/2004/01/pp-impl/95969/instructions"><div class="icon"><img src="https://image.flaticon.com/icons/svg/149/149387.svg" alt="" width="45"></div><div class="description"><h3>Join</h3><p>Learn how to become<br/>a WG participant.</p></div></a>
 		</div>
 	</div>
 

--- a/docs/wg/index.html
+++ b/docs/wg/index.html
@@ -41,36 +41,36 @@ group: "navigation"
 	</p>
 	<div class="row center-block">
 		<div class="col-md-12">
-			<table style="width: 100%">
+			<table style="width: 100%;">
 				<tr>
 					<th>Name</th>
-					<th>Deliverable</th>
-					<th>Task Force Lead</th>
+					<th style="text-align:center;">Deliverable</th>
+					<th style="text-align:right;">Task Force Lead</th>
 				</tr>
 				<tr>
 					<td><a href="{{'activities/tf-architecture/' | relative_url }}">WoT Architecture</a></td>
-					<td>WoT Architecture<br>WoT Profile</td>
-					<td><a href="mailto:michael.lagally@oracle.com">Michael Lagally (Oracle Corp.)</a></td>
+					<td style="text-align:right;">WoT Architecture<br>WoT Profile</td>
+					<td style="text-align:right;"><a href="mailto:michael.lagally@oracle.com">Michael Lagally (Oracle Corp.)</a></td>
 				</tr>
 				<tr>
 					<td><a href="{{'activities/tf-td/' | relative_url }}">WoT Thing Description</a></td>
-					<td>WoT Thing Description<br>WoT Binding Templates</td>
-					<td><a href="mailto:sebastian.kaebisch@siemens.com">Sebastian K&auml;bisch (Siemens)</a><br></td>
+					<td style="text-align:right;">WoT Thing Description<br>WoT Binding Templates</td>
+					<td style="text-align:right;"><a href="mailto:sebastian.kaebisch@siemens.com">Sebastian K&auml;bisch (Siemens)</a><br></td>
 				</tr>
 				<tr>
 					<td><a href="{{'activities/tf-discovery/' | relative_url }}">WoT Discovery</a></td>
-					<td>WoT Discovery</td>
-					<td><a href="mailto:michael.mccool@intel.com">Michael McCool (Intel)</a></td>
+					<td style="text-align:right;">WoT Discovery</td>
+					<td style="text-align:right;"><a href="mailto:michael.mccool@intel.com">Michael McCool (Intel)</a></td>
 				</tr>
 				<tr>
 					<td><a href="{{'activities/tf-security/' | relative_url }}">WoT Security</a></td>
-					<td>WoT Security</td>
-					<td><a href="mailto:michael.mccool@intel.com">Michael McCool (Intel)</a></td>
+					<td style="text-align:right;">WoT Security</td>
+					<td style="text-align:right;"><a href="mailto:michael.mccool@intel.com">Michael McCool (Intel)</a></td>
 				</tr>
 				<tr>
 					<td><a href="{{'activities/tf-scripting/' | relative_url }}">WoT Scripting API</a></td>
-					<td>WoT Scripting</td>
-					<td><a href="mailto:daniel.peintner.ext@siemens.com">Daniel Peintner (Siemens AG)</a></td>
+					<td style="text-align:right;">WoT Scripting</td>
+					<td style="text-align:right;"><a href="mailto:daniel.peintner.ext@siemens.com">Daniel Peintner (Siemens AG)</a></td>
 				</tr>
 			</table>
 		</div>


### PR DESCRIPTION
fixes https://github.com/w3c/wot-marketing/issues/153

- moves groups icons "before" task forces
- spells task forces everywhere the same 
- "stretch" task forces tables to full width to make it look better