### PR TITLE
update-end-date-till-31-dec-2021

### DIFF
--- a/docs/ig/index.html
+++ b/docs/ig/index.html
@@ -15,7 +15,7 @@ group: "navigation"
 	
 	<div class="row center-block">
 		<div class="col-md-6 text-center">
-			<a href="https://www.w3.org/2019/10/wot-ig-2019.html"><div class="icon"><img src="https://image.flaticon.com/icons/svg/149/149345.svg" alt="" width="45"></div><div class="description"><h3>IG Charter</h3><p>Active from 22 October 2019<br/>until 30 June 2021 .</p></div></a>
+			<a href="https://www.w3.org/2019/10/wot-ig-2019.html"><div class="icon"><img src="https://image.flaticon.com/icons/svg/149/149345.svg" alt="" width="45"></div><div class="description"><h3>IG Charter</h3><p>Active from 22 October 2019<br/>until 31 December 2021 .</p></div></a>
 		</div>
 		<div class="col-md-6 text-center">
 			<a href="https://lists.w3.org/Archives/Public/public-wot-ig/"><div class="icon"><img src="https://image.flaticon.com/icons/svg/131/131155.svg" alt="" width="45"></div><div class="description"><h3>Mailing List</h3><p>Public mailing list archive and sign-up.</p></div></a>


### PR DESCRIPTION
for IG Charter extension till 31 Dec 2021