### PR TITLE
Add marketing TF description

### DIFF
--- a/docs/activities/general/index.html
+++ b/docs/activities/general/index.html
@@ -17,7 +17,7 @@ group: "navigation"
 		<li><a href="{{'activities/tf-security/' | relative_url }}">WoT Security</a></li>
 		<li><a href="{{'activities/tf-scripting/' | relative_url }}">WoT Scripting API</a></li>
 		<li><a href="{{'activities/tf-usecases/' | relative_url }}">WoT Use Cases</a></li>
-		<!-- <li>WoT Marketing</li>
+		<li><a href="{{'activities/tf-marketing/' | relative_url }}">WoT Marketing</a></li>
 		<li>WoT PoC</li>
 		<li>WoT PlugFest</li> -->
 	</ul>

--- a/docs/activities/general/index.html
+++ b/docs/activities/general/index.html
@@ -19,7 +19,7 @@ group: "navigation"
 		<li><a href="{{'activities/tf-usecases/' | relative_url }}">WoT Use Cases</a></li>
 		<li><a href="{{'activities/tf-marketing/' | relative_url }}">WoT Marketing</a></li>
 		<li>WoT PoC</li>
-		<li>WoT PlugFest</li> -->
+		<li>WoT PlugFest</li>
 	</ul>
 	<br />
 	

--- a/docs/activities/general/index.html
+++ b/docs/activities/general/index.html
@@ -18,8 +18,10 @@ group: "navigation"
 		<li><a href="{{'activities/tf-scripting/' | relative_url }}">WoT Scripting API</a></li>
 		<li><a href="{{'activities/tf-usecases/' | relative_url }}">WoT Use Cases</a></li>
 		<li><a href="{{'activities/tf-marketing/' | relative_url }}">WoT Marketing</a></li>
+		<!--
 		<li>WoT PoC</li>
 		<li>WoT PlugFest</li>
+		-->
 	</ul>
 	<br />
 	

--- a/docs/activities/tf-architecture/index.html
+++ b/docs/activities/tf-architecture/index.html
@@ -60,8 +60,8 @@ group: "navigation"
         <h3>Resources</h3>
 	<ul>
         <li><a href="https://www.w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf">WoT Architecture TF Wiki (has meeting logistics)</a></li>
-        <li><a href="https://github.com/w3c/wot-architecture">WoT Architecture github repository</a></li>
-        <li><a href="https://github.com/w3c/wot-profile">WoT Profile github repository</a></li>
+        <li><a href="https://github.com/w3c/wot-architecture">WoT Architecture GitHub repository</a></li>
+        <li><a href="https://github.com/w3c/wot-profile">WoT Profile GitHub repository</a></li>
 	</ul>
     </div>
 </div>

--- a/docs/activities/tf-discovery/index.html
+++ b/docs/activities/tf-discovery/index.html
@@ -44,7 +44,7 @@ group: "navigation"
         <h3>Resources</h3>
 	<ul>
         <li><a href="https://www.w3.org/WoT/IG/wiki/WG_WoT_Discovery_WebConf">WoT Discovery TF Wiki (has meeting logistics)</a></li>
-        <li><a href="https://github.com/w3c/wot-discovery">WoT Discovery github repository</a></li>
+        <li><a href="https://github.com/w3c/wot-discovery">WoT Discovery GitHub repository</a></li>
 	</ul>
     </div>
 </div>

--- a/docs/activities/tf-marketing/index.html
+++ b/docs/activities/tf-marketing/index.html
@@ -1,0 +1,27 @@
+---
+layout: default
+title: Marketing Task Force
+group: "navigation"
+---
+<div>
+<h2>W3C WoT – Marketing Task Force</h2>
+    <p>The WoT Marketing task force is responsible for reaching out and collaborating with the community to increase the
+        adoption of the WoT. The Marketing Task Force works on promoting the W3C Web of Things in different ways such 
+        as Web presence, Social Media presence, and more.
+    </p>
+    <div>
+        <h3>People</h3>
+        <dl>
+            <dt>TF-Lead:</dt><dd>
+                Ege Korkan (Siemens AG)
+            </dd>
+        </dl>
+    </div>
+    <div>
+        <h3>Resources</h3>
+        <ul>
+            <li><a href="https://www.w3.org/WoT/IG/wiki/Marketing_WebConf">WoT Marketing TF Wiki (has meeting logistics)</a></li>
+            <li><a href="https://github.com/w3c/wot-marketing">WoT Marketing GitHub repository</a></li>
+        </ul>
+    </div>
+</div>

--- a/docs/activities/tf-scripting/index.html
+++ b/docs/activities/tf-scripting/index.html
@@ -35,7 +35,7 @@ group: "navigation"
 		<ul>
 			<li><a href="https://www.w3.org/TR/wot-scripting-api/">Web of Things (WoT) Scripting API Note</a></li>
 			<li><a href="https://www.w3.org/WoT/IG/wiki/WG_WoT_Scripting_API_WebConf">WoT Scripting API TF Wiki (has meeting logistics)</a></li>
-			<li><a href="https://github.com/w3c/wot-scripting-api">WoT Scripting API github repository</a></li>
+			<li><a href="https://github.com/w3c/wot-scripting-api">WoT Scripting API GitHub repository</a></li>
 		</ul>
     </div>
 </div>

--- a/docs/activities/tf-security/index.html
+++ b/docs/activities/tf-security/index.html
@@ -41,7 +41,7 @@ group: "navigation"
         <h3>Resources</h3>
 	<ul>
         <li><a href="https://www.w3.org/WoT/IG/wiki/IG_Security_WebConf">WoT Security TF Wiki (has meeting logistics)</a></li>
-        <li><a href="https://github.com/w3c/wot-security">WoT Security github repository</a></li>
+        <li><a href="https://github.com/w3c/wot-security">WoT Security GitHub repository</a></li>
 	</ul>
     </div>
 </div>

--- a/docs/activities/tf-td/index.html
+++ b/docs/activities/tf-td/index.html
@@ -48,6 +48,7 @@ group: "navigation"
 			<dt>WoT Thing Description Co-Editors:</dt><dd>
 				Sebastian Kaebisch (Siemens AG),
 				Takuki Kamiya (Fujitsu Laboratories of America),
+				Michael McCool (Intel),
 				Victor Charpenay (Siemens AG)
 			</dd>
 			<dt>WoT Binding Templates:</dt><dd>

--- a/docs/activities/tf-td/index.html
+++ b/docs/activities/tf-td/index.html
@@ -60,9 +60,9 @@ group: "navigation"
 			<h3>Resources</h3>
 		<ul>
 			<li><a href="https://www.w3.org/WoT/IG/wiki/WG_WoT_Thing_Description_WebConf">WoT Thing Description TF Wiki (has meeting logistics)</a></li>
-			<li><a href="https://github.com/w3c/wot-thing-description/">WoT Thing Description github repository</a></li>
+			<li><a href="https://github.com/w3c/wot-thing-description/">WoT Thing Description GitHub repository</a></li>
 			<li><a href="https://www.w3.org/TR/wot-thing-description11/">Web of Things (WoT) Thing Description 1.1</a></li>
-			<li><a href="https://github.com/w3c/wot-binding-templates/">WoT Binding Templates github repository</a></li>
+			<li><a href="https://github.com/w3c/wot-binding-templates/">WoT Binding Templates GitHub repository</a></li>
 			<li><a href="https://www.w3.org/TR/wot-binding-templates/">WoT Binding Templates Note</a></li>
 		</ul>
 		</div>

--- a/docs/activities/tf-usecases/index.html
+++ b/docs/activities/tf-usecases/index.html
@@ -43,7 +43,7 @@ group: "navigation"
         <h3>Resources</h3>
 	<ul>
         <li><a href="https://www.w3.org/WoT/IG/wiki/IG_UseCase_WebConf">WoT Use Cases TF Wiki (has meeting logistics)</a></li>
-        <li><a href="https://github.com/w3c/wot-usecases">WoT Use Cases github repository</a></li>
+        <li><a href="https://github.com/w3c/wot-usecases">WoT Use Cases GitHub repository</a></li>
 	</ul>
     </div>
 </div>

--- a/docs/ig/index.html
+++ b/docs/ig/index.html
@@ -55,7 +55,7 @@ group: "navigation"
 					<td style="text-align:right;"><a href="mailto:michael.lagally@oracle.com">Michael Lagally (Oracle Corp.)</a></td>
 				</tr>
 				<tr>
-					<td>WoT Marketing</td>
+					<td><a href="{{'activities/tf-marketing/' | relative_url }}">WoT Marketing</a></td>
 					<td style="text-align:center;">WoT Web Page, Collateral
 					<td style="text-align:right;"><a href="mailto:ege.korkan@siemens.com">Ege Korkan (Siemens)</a></td>
 				</tr>

--- a/docs/ig/index.html
+++ b/docs/ig/index.html
@@ -56,8 +56,8 @@ group: "navigation"
 				</tr>
 				<tr>
 					<td>WoT Marketing</td>
-					<td style="text-align:center;">WoT Wiki Page, Collateral
-					<td style="text-align:right;"><a href="mailto:sebastian.kaebisch@siemens.com">Sebastian K&auml;bisch (Siemens)</a></td>
+					<td style="text-align:center;">WoT Web Page, Collateral
+					<td style="text-align:right;"><a href="mailto:ege.korkan@siemens.com">Ege Korkan (Siemens)</a></td>
 				</tr>
 				<tr>
 					<td>WoT PoC</td>


### PR DESCRIPTION
I have also changed mention of github to GitHub in all TFs and added Michael McCool as a TD co editor

Some things do not exactly satisfy me:
- There is only my name as TF lead but there is no place to put the names since we do not have a document with co-editors. There are many others who contribute, I am mostly moderating.
- We do not have a deliverable, it looks as if the TF is not doing any work.

I think these are some signs that a CG would be more suitable. In any case, better to have this than nothing but the wiki links.