### PR TITLE
docs: move old events to past and add TestFest in February

### DIFF
--- a/docs/activities/general/index.html
+++ b/docs/activities/general/index.html
@@ -33,9 +33,9 @@ group: "navigation"
 		<li>
 			<strong>Upcoming</strong>
 			<ul>
-				<li><a href="https://www.iottechexpo.com/europe/">IoT Tech Expo Europe 2021</a>
+				<li><a target="_blank" href="https://www.iottechexpo.com/europe/">IoT Tech Expo Europe 2021</a>
 					<ul>
-						<li><a href="https://www.w3.org/blog/talks/event/live-panel-iot-security-acting-ahead-of-the-threat/">Live Panel: IoT Security – Acting Ahead of the Threat - November 30</a></li>
+						<li><a target="_blank" href="https://www.w3.org/blog/talks/event/live-panel-iot-security-acting-ahead-of-the-threat/">Live Panel: IoT Security – Acting Ahead of the Threat - November 30</a></li>
 					</ul>
 				</li>
 				<li>TestFest February 2022 (TBD)</li>
@@ -44,17 +44,17 @@ group: "navigation"
 		<li>
 			<strong>Past</strong>
 			<ul>
-				<li><a href="https://www.w3.org/WoT/IG/wiki/F2F_meeting,_October_2021">WoT at TPAC 2021</a></li>
-				<li><a href="https://www.w3.org/2021/10/TPAC/">TPAC 2021 - October 18-29 2021</a></li>
-				<li><a href="https://summit.riot-os.org/2021/">RIoT Summit September 9-10 2021</a></li>
-				<li><a href="https://www.iottechexpo.com/northamerica/track/iot-digital-infrastructures-day-1/">IoT Tech Expo September 29 2021</a></li>
-				<li><strike><a href="https://oeg-upm.github.io/DIoT/">DIoT November 8-12 2021</a></strike> (Cancelled)</li>
-				<li><a href="https://www.w3.org/WoT/IG/wiki/F2F_meeting,_June_2021#Testfest">Testfest - June 7-11 2021</a></li>
-				<li><a href="https://www.w3.org/WoT/IG/wiki/F2F_meeting,_June_2021#Virtual_F2F">Virtual F2F Meeting - June 21-July 2, 2021</a></li>
-				<li><a href="https://github.com/w3c/wot-testing/blob/master/events/2021.03.Online/README.md">Virtual F2F PlugFest - March 1-5, 2021 (joint plugfest with IETF hackathon)</a></li>
-				<li><a href="https://www.w3.org/WoT/IG/wiki/F2F_meeting,_March_2021">Virtual F2F meeting - March 15-26, 2021</a></li>
-				<li><a href="https://www.w3.org/WoT/IG/wiki/F2F_meeting,_October_2020">Virtual F2F meeting - October 2020</a></li>
-				<li><a href="https://www.w3.org/2020/10/TPAC/">TPAC 2020</a></li>
+				<li><a target="_blank" href="https://www.w3.org/WoT/IG/wiki/F2F_meeting,_October_2021">WoT at TPAC 2021</a></li>
+				<li><a target="_blank" href="https://www.w3.org/2021/10/TPAC/">TPAC 2021 - October 18-29 2021</a></li>
+				<li><a target="_blank" href="https://summit.riot-os.org/2021/">RIoT Summit September 9-10 2021</a></li>
+				<li><a target="_blank" href="https://www.iottechexpo.com/northamerica/track/iot-digital-infrastructures-day-1/">IoT Tech Expo September 29 2021</a></li>
+				<li><strike><a target="_blank" href="https://oeg-upm.github.io/DIoT/">DIoT November 8-12 2021</a></strike> (Cancelled)</li>
+				<li><a target="_blank" href="https://www.w3.org/WoT/IG/wiki/F2F_meeting,_June_2021#Testfest">Testfest - June 7-11 2021</a></li>
+				<li><a target="_blank" href="https://www.w3.org/WoT/IG/wiki/F2F_meeting,_June_2021#Virtual_F2F">Virtual F2F Meeting - June 21-July 2, 2021</a></li>
+				<li><a target="_blank" href="https://github.com/w3c/wot-testing/blob/master/events/2021.03.Online/README.md">Virtual F2F PlugFest - March 1-5, 2021 (joint plugfest with IETF hackathon)</a></li>
+				<li><a target="_blank" href="https://www.w3.org/WoT/IG/wiki/F2F_meeting,_March_2021">Virtual F2F meeting - March 15-26, 2021</a></li>
+				<li><a target="_blank" href="https://www.w3.org/WoT/IG/wiki/F2F_meeting,_October_2020">Virtual F2F meeting - October 2020</a></li>
+				<li><a target="_blank" href="https://www.w3.org/2020/10/TPAC/">TPAC 2020</a></li>
 			</ul>
 		</li>
 	</ul>

--- a/docs/activities/general/index.html
+++ b/docs/activities/general/index.html
@@ -33,6 +33,12 @@ group: "navigation"
 		<li>
 			<strong>Upcoming</strong>
 			<ul>
+				<li>TestFest February 2022 (TBD)</li>
+			</ul>
+		</li>
+		<li>
+			<strong>Past</strong>
+			<ul>
 				<li><a href="https://www.w3.org/WoT/IG/wiki/F2F_meeting,_October_2021">WoT at TPAC 2021</a>
 					<ul>
 						<li>PlugFest September 27-October 1</li>
@@ -47,17 +53,9 @@ group: "navigation"
 					</ul>
 				</li>
 				<li><a href="https://www.w3.org/2021/10/TPAC/">TPAC 2021 - October 18-29 2021</a></li>
-			</ul>
-			<hr style="width:25%;text-align:left;margin-left:0;" />
-			<ul>
 				<li><a href="https://summit.riot-os.org/2021/">RIoT Summit September 9-10 2021</a></li>
 				<li><a href="https://www.iottechexpo.com/northamerica/track/iot-digital-infrastructures-day-1/">IoT Tech Expo September 29 2021</a></li>
 				<li><strike><a href="https://oeg-upm.github.io/DIoT/">DIoT November 8-12 2021</a></strike> (Cancelled)</li>
-			</ul>
-		</li>
-		<li>
-			<strong>Past</strong>
-			<ul>
 				<li><a href="https://www.w3.org/WoT/IG/wiki/F2F_meeting,_June_2021#Testfest">Testfest - June 7-11 2021</a></li>
 				<li><a href="https://www.w3.org/WoT/IG/wiki/F2F_meeting,_June_2021#Virtual_F2F">Virtual F2F Meeting - June 21-July 2, 2021</a></li>
 				<li><a href="https://github.com/w3c/wot-testing/blob/master/events/2021.03.Online/README.md">Virtual F2F PlugFest - March 1-5, 2021 (joint plugfest with IETF hackathon)</a></li>

--- a/docs/activities/general/index.html
+++ b/docs/activities/general/index.html
@@ -39,19 +39,7 @@ group: "navigation"
 		<li>
 			<strong>Past</strong>
 			<ul>
-				<li><a href="https://www.w3.org/WoT/IG/wiki/F2F_meeting,_October_2021">WoT at TPAC 2021</a>
-					<ul>
-						<li>PlugFest September 27-October 1</li>
-						<li>Virtual F2F October 5, 7, 26, 27, 28</li>
-						<li>Joint meetings week of October 25</li>
-						<li>Open Days
-							<ul>
-								<li><a href="https://www.w3.org/WoT/IG/wiki/F2F_meeting,_October_2021#Oct_11_-_Open_Day">Oct 11</a></li>
-								<li><a href="https://www.w3.org/WoT/IG/wiki/F2F_meeting,_October_2021#Oct_14_-_Open_Day">Oct 14</a></li>
-							</ul>
-						</li>
-					</ul>
-				</li>
+				<li><a href="https://www.w3.org/WoT/IG/wiki/F2F_meeting,_October_2021">WoT at TPAC 2021</a></li>
 				<li><a href="https://www.w3.org/2021/10/TPAC/">TPAC 2021 - October 18-29 2021</a></li>
 				<li><a href="https://summit.riot-os.org/2021/">RIoT Summit September 9-10 2021</a></li>
 				<li><a href="https://www.iottechexpo.com/northamerica/track/iot-digital-infrastructures-day-1/">IoT Tech Expo September 29 2021</a></li>

--- a/docs/activities/general/index.html
+++ b/docs/activities/general/index.html
@@ -33,6 +33,11 @@ group: "navigation"
 		<li>
 			<strong>Upcoming</strong>
 			<ul>
+				<li><a href="https://www.iottechexpo.com/europe/">IoT Tech Expo Europe 2021</a>
+					<ul>
+						<li><a href="https://www.w3.org/blog/talks/event/live-panel-iot-security-acting-ahead-of-the-threat/">Live Panel: IoT Security – Acting Ahead of the Threat - November 30</a></li>
+					</ul>
+				</li>
 				<li>TestFest February 2022 (TBD)</li>
 			</ul>
 		</li>


### PR DESCRIPTION
fixes https://github.com/w3c/wot-marketing/issues/227