### PR TITLE
fix: use "Siemens AG" consistently

### DIFF
--- a/docs/ig/index.html
+++ b/docs/ig/index.html
@@ -8,7 +8,7 @@ group: "navigation"
 	<p>
 		The W3C WoT Interest Group (IG) plays a complementary role to the Working Group. The IG organizes and runs PlugFests to evaluate the current working assumptions, reaches out and collaborates with interested organizations, vendors, and communities, and explores new areas to identify work that is ready for transfer to the W3C Recommendation Track (i.e., any W3C Working Group).
 	</p>
-	<p>Co-Chairs: <a href="mailto:michael.mccool@intel.com">Michael McCool (Intel)</a> and <a href="mailto:sebastian.kaebisch@siemens.com">Sebastian K&auml;bisch (Siemens)</a></p>
+	<p>Co-Chairs: <a href="mailto:michael.mccool@intel.com">Michael McCool (Intel)</a> and <a href="mailto:sebastian.kaebisch@siemens.com">Sebastian K&auml;bisch (Siemens AG)</a></p>
 	<p>Team contacts: <a href="https://www.w3.org/People#ashimura" target="_blank">Kazuyuki Ashimura</a> and <a href="https://www.w3.org/People#dsr" target="_blank">Dave Raggett</a></p>
 	
 	<p>&nbsp;</p>
@@ -57,7 +57,7 @@ group: "navigation"
 				<tr>
 					<td><a href="{{'activities/tf-marketing/' | relative_url }}">WoT Marketing</a></td>
 					<td style="text-align:center;">WoT Web Page, Collateral
-					<td style="text-align:right;"><a href="mailto:ege.korkan@siemens.com">Ege Korkan (Siemens)</a></td>
+					<td style="text-align:right;"><a href="mailto:ege.korkan@siemens.com">Ege Korkan (Siemens AG)</a></td>
 				</tr>
 				<tr>
 					<td><a target="_blank" href="https://www.w3.org/WoT/IG/wiki/PoC_WebConf" target="_blank">WoT PoC</a></td>

--- a/docs/wg/index.html
+++ b/docs/wg/index.html
@@ -8,7 +8,7 @@ group: "navigation"
 	<p>
 		The W3C WoT Working Group (WG) is tasked to create standards-track specifications and test suites. To ensure royalty-free Web standards, participants must be W3C and WoT WG Members and acknowledge the <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/">W3C Patent Policy</a>.
 	</p>
-	<p>Co-Chairs: <a href="mailto:michael.mccool@intel.com">Michael McCool (Intel)</a> and <a href="mailto:sebastian.kaebisch@siemens.com">Sebastian K&auml;bisch (Siemens)</a></p>
+	<p>Co-Chairs: <a href="mailto:michael.mccool@intel.com">Michael McCool (Intel)</a> and <a href="mailto:sebastian.kaebisch@siemens.com">Sebastian K&auml;bisch (Siemens AG)</a></p>
 	<p>Team contacts: <a href="https://www.w3.org/People#ashimura" target="_blank">Kazuyuki Ashimura</a> and <a href="https://www.w3.org/People#dsr" target="_blank">Dave Raggett</a></p>
 	
 	<p>&nbsp;</p>
@@ -55,7 +55,7 @@ group: "navigation"
 				<tr>
 					<td><a href="{{'activities/tf-td/' | relative_url }}">WoT Thing Description</a></td>
 					<td style="text-align:center;">WoT Thing Description<br>WoT Binding Templates</td>
-					<td style="text-align:right;"><a href="mailto:sebastian.kaebisch@siemens.com">Sebastian K&auml;bisch (Siemens)</a><br></td>
+					<td style="text-align:right;"><a href="mailto:sebastian.kaebisch@siemens.com">Sebastian K&auml;bisch (Siemens AG)</a><br></td>
 				</tr>
 				<tr>
 					<td><a href="{{'activities/tf-discovery/' | relative_url }}">WoT Discovery</a></td>


### PR DESCRIPTION
fixes https://github.com/w3c/wot-marketing/issues/264