### PR TITLE
Correct Calendar - Architecture

### DIFF
--- a/docs/activities/general/index.html
+++ b/docs/activities/general/index.html
@@ -319,11 +319,11 @@ function updateTimezone() {
 
 		<tr>
 			<th style="background-color: #FEFEEE; text-align:center;">Thu</th>
-			<td style="text-align:center;">-</td>
 			<td style="background-color: #FEEEDD; text-align:center;"><a rel="nofollow" class="external text"
 					href="https://www.w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf" target="_blank">WoT Architecture</a><br><a rel="nofollow"
 					class="external text" href="https://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0007.html" target="_blank">(WebEx)</a>
 			</td>
+			<td style="text-align:center;">-</td>
 			<td style="text-align:center;">-</td>
 			<td style="text-align:center;">-</td>
 			<td style="text-align:center;">-</td>


### PR DESCRIPTION
Move Architecture an hour earlier; it was shown at the wrong time.