### PR TITLE
Add new tool organization

### DIFF
--- a/docs/developers/index.html
+++ b/docs/developers/index.html
@@ -5,7 +5,6 @@ group: "navigation"
 ---
 <div>
 
-<!-- TODO: find a way to put tags for categories -->
 		<div class="row center-block">
 			<div class="col-md-6 text-center">
 				<a href="#td-tooling"><i class="fas fa-edit fa-4x"></i> 
@@ -83,7 +82,7 @@ group: "navigation"
 				</a>
 			</div>
 		</div>
-
+<!-- 
 <p>Alternative</p>
 
 <style type="text/css">
@@ -432,7 +431,7 @@ group: "navigation"
 			<td class="tg-73oq">-</td>
 		</tr>
 	</tbody>
-</table>
+</table> -->
 
 	<h3 id="td-tooling">TD Tooling</h3>
 	<ul>

--- a/docs/developers/index.html
+++ b/docs/developers/index.html
@@ -4,7 +4,6 @@ title: Developers
 group: "navigation"
 ---
 <div>
-	<h2>Web of Things for Developers</h2>
 
 <!-- TODO: find a way to put tags for categories -->
 		<div class="row center-block">
@@ -84,6 +83,356 @@ group: "navigation"
 				</a>
 			</div>
 		</div>
+
+<p>Alternative</p>
+
+<style type="text/css">
+	.tg {
+		border-collapse: collapse;
+		border-spacing: 0;
+	}
+
+	.tg td {
+		border-color: black;
+		border-style: solid;
+		border-width: 1px;
+		font-family: Arial, sans-serif;
+		font-size: 14px;
+		overflow: hidden;
+		padding: 10px 5px;
+		word-break: normal;
+	}
+
+	.tg th {
+		border-color: black;
+		border-style: solid;
+		border-width: 1px;
+		font-family: Arial, sans-serif;
+		font-size: 14px;
+		font-weight: normal;
+		overflow: hidden;
+		padding: 10px 5px;
+		word-break: normal;
+	}
+
+	.tg .tg-vfn0 {
+		background-color: #efefef;
+		border-color: #000000;
+		text-align: left;
+		vertical-align: top
+	}
+
+	.tg .tg-73oq {
+		border-color: #000000;
+		text-align: left;
+		vertical-align: top
+	}
+</style>
+<table class="tg">
+	<thead>
+		<tr>
+			<th class="tg-73oq"></th>
+			<th class="tg-73oq">TD Tooling<br></th>
+			<th class="tg-73oq">User Interfaces</th>
+			<th class="tg-73oq">Development Environment</th>
+			<th class="tg-73oq">Consumer</th>
+			<th class="tg-73oq">Exposer</th>
+			<th class="tg-73oq">TD Directory</th>
+			<th class="tg-73oq">TD Discovery</th>
+			<th class="tg-73oq">Gateway Service</th>
+			<th class="tg-73oq">Testing</th>
+			<th class="tg-73oq">Simulation</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="tg-vfn0">Playground</td>
+			<td class="tg-vfn0">UI</td>
+			<td class="tg-vfn0">+<br></td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">+<br></td>
+			<td class="tg-vfn0">-</td>
+		</tr>
+		<tr>
+			<td class="tg-73oq">Eclipse Edi{TD}or</td>
+			<td class="tg-73oq">UI</td>
+			<td class="tg-73oq">+<br></td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">+</td>
+			<td class="tg-73oq">-</td>
+		</tr>
+		<tr>
+			<td class="tg-vfn0">TD-Code</td>
+			<td class="tg-vfn0">Editor Plugin<br></td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">+</td>
+			<td class="tg-vfn0">-</td>
+		</tr>
+		<tr>
+			<td class="tg-73oq">WoT-JTD</td>
+			<td class="tg-73oq">Programmatic</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+		</tr>
+		<tr>
+			<td class="tg-vfn0">Eclipse Ditto :: WoT :: Model</td>
+			<td class="tg-vfn0">Programmatic</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+		</tr>
+		<tr>
+			<td class="tg-73oq">WoT Application Manager (WAM)</td>
+			<td class="tg-73oq">-<br></td>
+			<td class="tg-73oq">-<br></td>
+			<td class="tg-73oq">+<br></td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+		</tr>
+		<tr>
+			<td class="tg-vfn0">WoT API Development Environment (WADE)</td>
+			<td class="tg-vfn0">UI</td>
+			<td class="tg-vfn0">+<br></td>
+			<td class="tg-vfn0">+<br></td>
+			<td class="tg-vfn0">+</td>
+			<td class="tg-vfn0">+</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">+</td>
+			<td class="tg-vfn0">+</td>
+		</tr>
+		<tr>
+			<td class="tg-73oq">WoT FXUI</td>
+			<td class="tg-73oq">-<br></td>
+			<td class="tg-73oq">+<br></td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">+</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+		</tr>
+		<tr>
+			<td class="tg-vfn0">Eclipse Thingweb node-wot</td>
+			<td class="tg-vfn0">Programmatic</td>
+			<td class="tg-vfn0">-<br></td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">+</td>
+			<td class="tg-vfn0">+</td>
+			<td class="tg-vfn0">partially</td>
+			<td class="tg-vfn0">partially</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+		</tr>
+		<tr>
+			<td class="tg-73oq">Eclipse Ditto</td>
+			<td class="tg-73oq">Programmatic</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">+</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+		</tr>
+		<tr>
+			<td class="tg-vfn0">SANE WoT Servient</td>
+			<td class="tg-vfn0">Programmatic</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">+</td>
+			<td class="tg-vfn0">+</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+		</tr>
+		<tr>
+			<td class="tg-73oq">WoTPy</td>
+			<td class="tg-73oq">Programmatic</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">+</td>
+			<td class="tg-73oq">+</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+		</tr>
+		<tr>
+			<td class="tg-vfn0">Node-Red Node generator</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">+</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+		</tr>
+		<tr>
+			<td class="tg-73oq">dart_wot</td>
+			<td class="tg-73oq">?</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">+</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+		</tr>
+		<tr>
+			<td class="tg-vfn0">LinkSmart Thing Directory</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">+</td>
+			<td class="tg-vfn0">+</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+		</tr>
+		<tr>
+			<td class="tg-73oq">WoTHive Thing Directory</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">+</td>
+			<td class="tg-73oq">+</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+		</tr>
+		<tr>
+			<td class="tg-vfn0">Siemens-Logilab Thing Directory</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">+</td>
+			<td class="tg-vfn0">+</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+		</tr>
+		<tr>
+			<td class="tg-73oq">Shadow Thing</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">+</td>
+			<td class="tg-73oq">+</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">+</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">+</td>
+		</tr>
+		<tr>
+			<td class="tg-vfn0">sayWoT!</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">+</td>
+			<td class="tg-vfn0">+</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">+</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+		</tr>
+		<tr>
+			<td class="tg-73oq">Test Bench</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">+</td>
+			<td class="tg-73oq">+</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">+</td>
+			<td class="tg-73oq">-<br></td>
+		</tr>
+		<tr>
+			<td class="tg-vfn0">WoT Plugin for AASX Package Explorer</td>
+			<td class="tg-vfn0">UI</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+			<td class="tg-vfn0">-</td>
+		</tr>
+		<tr>
+			<td class="tg-73oq">WoTify</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+			<td class="tg-73oq">-</td>
+		</tr>
+	</tbody>
+</table>
 
 	<h3 id="td-tooling">TD Tooling</h3>
 	<ul>
@@ -195,7 +544,7 @@ group: "navigation"
 			- Experimental W3C Web of Things implementation in Python with support for multiple bindings.
 		</li>
 	</ul>
-	
+
 	<h3 id="tdds">TD Directory (TDD) Implementations</h3>
 	<ul>
 		<li>

--- a/docs/developers/index.html
+++ b/docs/developers/index.html
@@ -4,9 +4,88 @@ title: Developers
 group: "navigation"
 ---
 <div>
-	<h2>Developer Tools</h2>
+	<h2>Web of Things for Developers</h2>
 
-	<h3>Thing Description (TD) Tooling</h3>
+<!-- TODO: find a way to put tags for categories -->
+		<div class="row center-block">
+			<div class="col-md-6 text-center">
+				<a href="#td-tooling"><i class="fas fa-edit fa-4x"></i> 
+					<!-- alternative pen-paintbrush -->
+					<div class="description">
+						<h3>TD Tooling</h3>
+						<p>Services that host a Thing Description Directory which implements the W3C WoT Discovery specification</p>
+					</div>
+				</a>
+			</div>
+			<div class="col-md-6 text-center">
+				<a href="#devtools"><i class="fas fa-laptop-code fa-4x"></i>
+					<div class="description">
+						<h3>Development Tools</h3>
+						<p>Ready-to-use tools that help the development of WoT applications by providing user interfaces and other tooling</p>
+					</div>
+				</a>
+			</div>
+		</div>
+		
+		<p>&nbsp;</p>
+
+		<div class="row center-block">
+			<div class="col-md-6 text-center">
+				<a href="#runtime-expose"><i class="fas fa-upload fa-4x"></i>
+					<div class="description">
+						<h3>Runtimes for TD Exposers</h3>
+						<p>Software libraries that implement a WoT Runtime so that Things can be built following the WoT paradigms.
+						</p>
+					</div>
+				</a>
+			</div>
+			<div class="col-md-6 text-center">
+				<a href="#runtime-consume"><i class="fas fa-download fa-4x"></i>
+					<div class="description">
+						<h3>Runtimes for TD Consumers</h3>
+						<p>Software libraries that implement a WoT Runtime so that Things can be consumed and custom applications can be built on top, following the WoT paradigms.</p>
+					</div>
+				</a>
+			</div>
+		</div>
+
+		<p>&nbsp;</p>
+		
+		<div class="row center-block">
+			<div class="col-md-6 text-center">
+				<a href="#tdds"><i class="fas fa-database fa-4x"></i>
+					<div class="description">
+						<h3>TD Directories</h3>
+						<p>Services that host a Thing Description Directory which implements the W3C WoT Discovery specification.</p>
+					</div>
+				</a>
+			</div>
+			<div class="col-md-6 text-center">
+				<a href="#software"><i class="fas fa-puzzle-piece fa-4x"></i>
+					<!-- server,  -->
+					<div class="description">
+						<h3>WoT Software and Middleware</h3>
+						<p>Ready to use software applications that can be deployed in order to provide a certain functionality in a system, such as
+						gateway and proxying, simulation, testing services.</p>
+					</div>
+				</a>
+			</div>
+		</div>
+
+		<p>&nbsp;</p>
+		
+		<div class="row center-block">
+			<div class="text-center">
+				<a href="#others"><i class="fas fa-cubes fa-4x"></i> 
+					<div class="description">
+						<h3>Others</h3>
+						<p></p>
+					</div>
+				</a>
+			</div>
+		</div>
+
+	<h3 id="td-tooling">TD Tooling</h3>
 	<ul>
 		<li><a href="http://plugfest.thingweb.io/playground/" target="_blank">Thing Description Playground</a>
 			- Reference TD Validation suite with additional tools such as OpenAPI generation, linting and more.
@@ -33,7 +112,33 @@ group: "navigation"
 
 	</ul>
 
-	<h3>WoT Implementations</h3>
+	<h3 id="devtools">Development Tools</h3>
+	<ul>
+		<li><a href="https://github.com/UniBO-PRISMLab/wam" target="_blank">WoT Application Manager (WAM)</a>
+			- CLI tool to quickly set up node-wot application projects. Additional information available at <a
+				href="WoT%20Application%20Manager.pdf" target="_blank">slides</a> or
+			<a href="https://youtu.be/bPxIfZo7jns" target="_blank">video</a>.
+			<!-- See the presentation and video for further information: <a
+					href="WoT%20Application%20Manager.pdf" target="_blank">slides</a> or
+				<a href="https://youtu.be/bPxIfZo7jns" target="_blank">video</a> -->
+		</li>
+		<li>
+			<a href="https://github.com/tum-esi/wade" target="_blank">WoT API Development Environment (WADE)</a>
+			- Desktop application based on node-wot, Vue.js and Electron that allows interaction with Things, profiling,
+			Mashup
+			generation.
+		</li>
+		<li>
+			<a href="https://github.com/danielpeintner/wot-fxui" target="_blank">WoT FXUI</a>
+			- UI for desktop, mobile, browser for interacting with Things based on their TDs.
+			<!-- <ul>
+							<li>See <a href="http://plugfest.thingweb.io:8088/test/fullscreen/default" target="_blank">running
+									Web-UI instance</a></li>
+						</ul> -->
+		</li>
+	</ul>
+
+	<h3 id="runtime-expose">Runtime Implementations for TD Exposers</h3>
 	<ul>
 		<li>
 			<a href="https://github.com/eclipse/thingweb.node-wot" target="_blank">Eclipse Thingweb node-wot</a> 
@@ -45,35 +150,53 @@ group: "navigation"
 					and <a href="http://www.thingweb.io/videos.html" target="_blank">videos</a> for node-wot</li>
 			</ul> -->
 		</li>
-		<li>
-			<a href="https://github.com/node-red/node-red-nodegen" target="_blank">Node-Red Node generator</a>
-			- CLI tool to generate WoT Consumer Nodes for <a href="https://nodered.org/" target="_blank">Node-RED</a> from a TD.
-			Additional information at <a href="wot_nodegen.pptx" target="_blank">slides</a>
-			or <a href="wot_nodegen.mp4" target="_blank">video</a>.
-			<!-- <ul>
-				<li>See a short introduction <a href="wot_nodegen.pptx" target="_blank">slides</a>
-					or <a href="wot_nodegen.mp4" target="_blank">video</a> for Node Generator</li>
-			</ul> -->
+		<li><a href="https://www.eclipse.org/ditto/basic-wot-integration.html" target="_blank">WoT Integration for
+				Eclipse Ditto</a>
+			- Ditto managed digital twins can be linked to WoT Thing Models from which Ditto can create Thing Descriptions
+			containing the API descriptions of the twins.
 		</li>
 		<li>
 			<a href="https://github.com/sane-city/wot-servient" target="_blank">SANE WoT Servient</a>
 			- W3C Web of Things implementation in Java with support for multiple bindings, inspired from node-wot.
 		</li>
 		<li>
-			<a href="https://github.com/agmangas/wot-py" target="_blank">WoTPy</a> 
+			<a href="https://github.com/agmangas/wot-py" target="_blank">WoTPy</a>
 			- Experimental W3C Web of Things implementation in Python with support for multiple bindings.
-		</li>
-		<li>
-			<a href="https://www.evosoft.com/en/digitalization-offering/saywot/" target="_blank">sayWoT!</a> 
-			- Industrial-grade implementation that allows integration of devices into Siemens software products.
-		</li>
-		<li>
-			<a href="https://pub.dev/packages/dart_wot" target="_blank">dart_wot</a> 
-			- W3C Web of Things implementation written in Dart with support for HTTP and CoAP.
 		</li>
 	</ul>
 
-	<h3>Thing Description Directory (TDD) Implementations</h3>
+	<h3 id="runtime-consume">Runtime Implementations for TD Consumers</h3>
+	<ul>
+		<li>
+			<a href="https://github.com/eclipse/thingweb.node-wot" target="_blank">Eclipse Thingweb node-wot</a>
+			- W3C Web of Things implementation in Node.js with support for multiple bindings. A website is available at
+			<a href="http://thingweb.io" target="_blank">Thingweb</a>.
+		</li>
+		<li>
+			<a href="https://github.com/node-red/node-red-nodegen" target="_blank">Node-Red Node generator</a>
+			- CLI tool to generate WoT Consumer Nodes for <a href="https://nodered.org/" target="_blank">Node-RED</a> from a TD.
+			Additional information at <a href="wot_nodegen.pptx" target="_blank">slides</a>
+			or <a href="wot_nodegen.mp4" target="_blank">video</a>.
+			<!-- <ul>
+						<li>See a short introduction <a href="wot_nodegen.pptx" target="_blank">slides</a>
+							or <a href="wot_nodegen.mp4" target="_blank">video</a> for Node Generator</li>
+					</ul> -->
+		</li>
+		<li>
+			<a href="https://pub.dev/packages/dart_wot" target="_blank">dart_wot</a>
+			- W3C Web of Things implementation written in Dart with support for HTTP and CoAP.
+		</li>
+		<li>
+			<a href="https://github.com/sane-city/wot-servient" target="_blank">SANE WoT Servient</a>
+			- W3C Web of Things implementation in Java with support for multiple bindings, inspired from node-wot.
+		</li>
+		<li>
+			<a href="https://github.com/agmangas/wot-py" target="_blank">WoTPy</a>
+			- Experimental W3C Web of Things implementation in Python with support for multiple bindings.
+		</li>
+	</ul>
+	
+	<h3 id="tdds">TD Directory (TDD) Implementations</h3>
 	<ul>
 		<li>
 			<a href="https://github.com/linksmart/thing-directory" target="_blank">LinkSmart Thing Directory</a>
@@ -89,43 +212,25 @@ group: "navigation"
 		</li>
 	</ul>
 
-	<h3>WoT Application Development Tools</h3>
+	<h3 id="software">WoT Software and Middleware</h3>
 	<ul>
-		<li><a href="https://github.com/UniBO-PRISMLab/wam" target="_blank">WoT Application Manager (WAM)</a>
-			- CLI tool to quickly set up node-wot application projects. Additional information available at <a href="WoT%20Application%20Manager.pdf" target="_blank">slides</a> or
-			<a href="https://youtu.be/bPxIfZo7jns" target="_blank">video</a>.
-			<!-- See the presentation and video for further information: <a
-				href="WoT%20Application%20Manager.pdf" target="_blank">slides</a> or
-			<a href="https://youtu.be/bPxIfZo7jns" target="_blank">video</a> -->
-		</li>
-		<li>
-			<a href="https://github.com/tum-esi/wade" target="_blank">WoT API Development Environment (WADE)</a>
-			- Desktop application based on node-wot, Vue.js and Electron that allows interaction with Things, profiling, Mashup
-			generation.
-		</li>
-		<li>
-			<a href="https://github.com/danielpeintner/wot-fxui" target="_blank">WoT FXUI</a>
-			- UI for desktop, mobile, browser for interacting with Things based on their TDs.
-			<!-- <ul>
-						<li>See <a href="http://plugfest.thingweb.io:8088/test/fullscreen/default" target="_blank">running
-								Web-UI instance</a></li>
-					</ul> -->
-		</li>
 		<li><a href="https://github.com/tum-esi/shadow-thing" target="_blank">Shadow Thing</a>
-			- CLI based tool for creating and deploying a Thing based on its TD for simulation, proxy or protocol translation
+			- CLI based tool for creating and deploying a Thing based on its TD for simulation, proxy or protocol
+			translation
 			purposes.
+		</li>
+		<li>
+			<a href="https://www.evosoft.com/en/digitalization-offering/saywot/" target="_blank">sayWoT!</a>
+			- Industrial-grade implementation that allows integration of devices into Siemens software products.
 		</li>
 		<li><a href="https://github.com/tum-esi/testbench" target="_blank">Web of Things Test Bench</a>
 			- CLI based tool that tests a WoT Thing by executing interactions automatically, based on its TD.
 		</li>
 	</ul>
-	<h3>Others</h3>
+
+	<h3 id="others">Others</h3>
 	<ul>
-		<li><a href="https://www.eclipse.org/ditto/basic-wot-integration.html" target="_blank">WoT Integration for
-				Eclipse Ditto</a>
-			- Ditto managed digital twins can be linked to WoT Thing Models from which Ditto can create Thing Descriptions
-			containing the API descriptions of the twins.
-		</li>
+
 		<li><a href="https://github.com/admin-shell-io/aasx-package-explorer" target="_blank">WoT Plugin for AASX
 				Package Explorer</a>
 			- Plugin to import/export WoT Thing Description into Asset Administration Shell definitions.

--- a/docs/developers/index.html
+++ b/docs/developers/index.html
@@ -4,6 +4,12 @@ title: Developers
 group: "navigation"
 ---
 <div>
+		<h2>Developer Tooling</h2>
+		
+		<p>
+			There are various tools developed by the community that are open source and ready to use. They can be used
+			in different stages of development or development needs and are grouped below.
+		</p>
 
 		<div class="row center-block">
 			<div class="col-md-6 text-center">
@@ -11,7 +17,6 @@ group: "navigation"
 					<!-- alternative pen-paintbrush -->
 					<div class="description">
 						<h3>TD Tooling</h3>
-						<p>Services that host a Thing Description Directory which implements the W3C WoT Discovery specification</p>
 					</div>
 				</a>
 			</div>
@@ -19,7 +24,6 @@ group: "navigation"
 				<a href="#devtools"><i class="fas fa-laptop-code fa-4x"></i>
 					<div class="description">
 						<h3>Development Tools</h3>
-						<p>Ready-to-use tools that help the development of WoT applications by providing user interfaces and other tooling</p>
 					</div>
 				</a>
 			</div>
@@ -32,8 +36,6 @@ group: "navigation"
 				<a href="#runtime-expose"><i class="fas fa-upload fa-4x"></i>
 					<div class="description">
 						<h3>Runtimes for TD Exposers</h3>
-						<p>Software libraries that implement a WoT Runtime so that Things can be built following the WoT paradigms.
-						</p>
 					</div>
 				</a>
 			</div>
@@ -41,7 +43,6 @@ group: "navigation"
 				<a href="#runtime-consume"><i class="fas fa-download fa-4x"></i>
 					<div class="description">
 						<h3>Runtimes for TD Consumers</h3>
-						<p>Software libraries that implement a WoT Runtime so that Things can be consumed and custom applications can be built on top, following the WoT paradigms.</p>
 					</div>
 				</a>
 			</div>
@@ -54,7 +55,6 @@ group: "navigation"
 				<a href="#tdds"><i class="fas fa-database fa-4x"></i>
 					<div class="description">
 						<h3>TD Directories</h3>
-						<p>Services that host a Thing Description Directory which implements the W3C WoT Discovery specification.</p>
 					</div>
 				</a>
 			</div>
@@ -63,8 +63,6 @@ group: "navigation"
 					<!-- server,  -->
 					<div class="description">
 						<h3>WoT Software and Middleware</h3>
-						<p>Ready to use software applications that can be deployed in order to provide a certain functionality in a system, such as
-						gateway and proxying, simulation, testing services.</p>
 					</div>
 				</a>
 			</div>
@@ -433,7 +431,10 @@ group: "navigation"
 	</tbody>
 </table> -->
 
+	<hr>
+	
 	<h3 id="td-tooling">TD Tooling</h3>
+	<p>Services that host a Thing Description Directory which implements the W3C WoT Discovery specification</p>
 	<ul>
 		<li><a href="http://plugfest.thingweb.io/playground/" target="_blank">Thing Description Playground</a>
 			- Reference TD Validation suite with additional tools such as OpenAPI generation, linting and more.
@@ -461,6 +462,7 @@ group: "navigation"
 	</ul>
 
 	<h3 id="devtools">Development Tools</h3>
+	<p>Ready-to-use tools that help the development of WoT applications by providing user interfaces and other tooling</p>
 	<ul>
 		<li><a href="https://github.com/UniBO-PRISMLab/wam" target="_blank">WoT Application Manager (WAM)</a>
 			- CLI tool to quickly set up node-wot application projects. Additional information available at <a
@@ -487,6 +489,8 @@ group: "navigation"
 	</ul>
 
 	<h3 id="runtime-expose">Runtime Implementations for TD Exposers</h3>
+	<p>Software libraries that implement a WoT Runtime so that Things can be built following the WoT paradigms.
+	</p>
 	<ul>
 		<li>
 			<a href="https://github.com/eclipse/thingweb.node-wot" target="_blank">Eclipse Thingweb node-wot</a> 
@@ -514,6 +518,8 @@ group: "navigation"
 	</ul>
 
 	<h3 id="runtime-consume">Runtime Implementations for TD Consumers</h3>
+	<p>Software libraries that implement a WoT Runtime so that Things can be consumed and custom applications can be built
+		on top, following the WoT paradigms.</p>
 	<ul>
 		<li>
 			<a href="https://github.com/eclipse/thingweb.node-wot" target="_blank">Eclipse Thingweb node-wot</a>
@@ -545,6 +551,7 @@ group: "navigation"
 	</ul>
 
 	<h3 id="tdds">TD Directory (TDD) Implementations</h3>
+	<p>Services that host a Thing Description Directory which implements the W3C WoT Discovery specification.</p>
 	<ul>
 		<li>
 			<a href="https://github.com/linksmart/thing-directory" target="_blank">LinkSmart Thing Directory</a>
@@ -561,6 +568,8 @@ group: "navigation"
 	</ul>
 
 	<h3 id="software">WoT Software and Middleware</h3>
+	<p>Ready to use software applications that can be deployed in order to provide a certain functionality in a system, such
+		as gateway and proxying, simulation, testing services.</p>
 	<ul>
 		<li><a href="https://github.com/tum-esi/shadow-thing" target="_blank">Shadow Thing</a>
 			- CLI based tool for creating and deploying a Thing based on its TD for simulation, proxy or protocol

--- a/docs/developers/index.html
+++ b/docs/developers/index.html
@@ -11,6 +11,8 @@ group: "navigation"
 			in different stages of development or development needs and are grouped below.
 		</p>
 
+		<br />
+		
 		<div class="row center-block">
 			<div class="col-md-6 text-center">
 				<a href="#td-tooling"><i class="fas fa-edit fa-4x"></i> 
@@ -23,7 +25,7 @@ group: "navigation"
 			<div class="col-md-6 text-center">
 				<a href="#devtools"><i class="fas fa-laptop-code fa-4x"></i>
 					<div class="description">
-						<h3>Development Tools</h3>
+						<h3>WoT Development Tools</h3>
 					</div>
 				</a>
 			</div>
@@ -434,7 +436,10 @@ group: "navigation"
 	<hr>
 	
 	<h3 id="td-tooling">TD Tooling</h3>
-	<p>Services that host a Thing Description Directory which implements the W3C WoT Discovery specification</p>
+	<p>
+		Tools that allow editing and validation of TDs or that allows parsing them in programming language specific 
+		environments.
+	</p>
 	<ul>
 		<li><a href="http://plugfest.thingweb.io/playground/" target="_blank">Thing Description Playground</a>
 			- Reference TD Validation suite with additional tools such as OpenAPI generation, linting and more.
@@ -461,8 +466,8 @@ group: "navigation"
 
 	</ul>
 
-	<h3 id="devtools">Development Tools</h3>
-	<p>Ready-to-use tools that help the development of WoT applications by providing user interfaces and other tooling</p>
+	<h3 id="devtools">WoT Development Tools</h3>
+	<p>Ready-to-use tools that help the development of WoT applications by providing user interfaces and other tooling.</p>
 	<ul>
 		<li><a href="https://github.com/UniBO-PRISMLab/wam" target="_blank">WoT Application Manager (WAM)</a>
 			- CLI tool to quickly set up node-wot application projects. Additional information available at <a

--- a/docs/developers/index.html
+++ b/docs/developers/index.html
@@ -12,7 +12,7 @@ group: "navigation"
 		</p>
 
 		<br />
-		
+
 		<div class="row center-block">
 			<div class="col-md-6 text-center">
 				<a href="#td-tooling"><i class="fas fa-edit fa-4x"></i> 
@@ -437,7 +437,7 @@ group: "navigation"
 	
 	<h3 id="td-tooling">TD Tooling</h3>
 	<p>
-		Tools that allow editing and validation of TDs or that allows parsing them in programming language specific 
+		Tools that allow editing and validation of TDs or that allow parsing them in programming language specific 
 		environments.
 	</p>
 	<ul>


### PR DESCRIPTION
I have added a category matrix and a table of tools with the features they cover. This is a draft and not intended to be the final look of the page, the table is very basic for sure. My opinions:
- Doing a table of features blows up the table horizontally. I can reduce the granularity.
- Doing a table was nice to see what features are implemented in which tool. I did it with my knowledge and not looking into tools' source codes.
- It is annoying to assign some projects to a single category and table works better in those cases.

- I think that listing the features is nice but a table like this is not a good design or visualization method. It is too high/long (we cannot do anything about that) and too wide (can be simplified)

Looking forward to what people think