### PR TITLE
update WG Charter dates

### DIFF
--- a/docs/wg/index.html
+++ b/docs/wg/index.html
@@ -15,7 +15,7 @@ group: "navigation"
 
 	<div class="row center-block">
 		<div class="col-md-6 text-center">
-			<a href="https://www.w3.org/2020/01/wot-wg-charter.html" target="_blank"><i class="fas fa-file-alt fa-4x"></i><div class="description"><h3>WG Charter</h3><p>Active from 31 January 2020<br/>until 31 May 2022.</p></div></a>
+			<a href="https://www.w3.org/2022/07/wot-wg-2022.html" target="_blank"><i class="fas fa-file-alt fa-4x"></i><div class="description"><h3>WG Charter</h3><p>Active from 28 July 2022<br/>until 31 January 2023.</p></div></a>
 		</div>
 		<div class="col-md-6 text-center">
 			<a href="https://lists.w3.org/Archives/Member/member-wot-wg/" target="_blank"><i class="fas fa-envelope fa-4x"></i><div class="description"><h3>Mailing List</h3><p>Member mailing list archive.</p></div></a>


### PR DESCRIPTION
As announced on the [WoT WG public mailinglist](https://lists.w3.org/Archives/Public/public-wot-wg/2022Jul/0022.html), the Charter of the WoT WG has been renewed, so the WoT WG page should be also updated with the URL and the start/end dates based on the [new Charter](https://www.w3.org/2022/07/wot-wg-2022.html).

Note that the WG participants need to rejoin the group within 45 days, because the renewed WG operates under the [W3C Patent Policy 2020](https://www.w3.org/Consortium/Patent-Policy-20200915/).