### PR TITLE
Add sifis-home projects to developer related tools

### DIFF
--- a/docs/developers/index.html
+++ b/docs/developers/index.html
@@ -463,6 +463,9 @@ group: "navigation"
 				Model</a>
 			- Java module for using TDs and TMs.
 		</li>
+		<li><a href="https://github.com/sifis-home/wot-td" target="_blank">SIFIS-Home: wot-td</a>
+			- Rust crate to produce and consume Web of Things Thing Descriptions.
+		</li>
 
 	</ul>
 
@@ -520,6 +523,10 @@ group: "navigation"
 			<a href="https://github.com/agmangas/wot-py" target="_blank">WoTPy</a>
 			- Experimental W3C Web of Things implementation in Python with support for multiple bindings.
 		</li>
+		<li>
+			<a href="https://github.com/sifis-home/wot-serve" target="_blank">SIFIS-Home: wot-serve</a>
+			- Rust crate to serve Web of Things Things.
+		</li>
 	</ul>
 
 	<h3 id="runtime-consume">Runtime Implementations for TD Consumers</h3>
@@ -569,6 +576,10 @@ group: "navigation"
 		<li>
 			<a href="https://2021.semweb.pro/presentations/siemens-feedback-on-implementing-a-thing-description-repository-using-a-sparql-endpoint/" target="_blank">Siemens-Logilab Thing Directory</a> 
 			- TDD implementation with features such as SPARQL queries, contextual validation and more.
+		</li>
+		<li>
+			<a href="https://github.com/sifis-home/wot-discovery" target="_blank">SIFIS-Home: wot-discovery</a> 
+			- Tiny implementation of WoT Discovery written in Rust.
 		</li>
 	</ul>
 


### PR DESCRIPTION
This PR adds the currently usable projects under the SIFIS-Home project (https://github.com/sifis-home and https://www.sifis-home.eu/). They are mostly developed by @lu-zero and @dodomorandi so it would be nice to get a review from them as well

fixes #345 