### PR TITLE
Webpage Contribution rules

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,16 @@ The content will be exposed to
 * https://w3c.github.io/wot-marketing/ (GitHub pages render)
 * https://wot-marketing.netlify.app/ (Netlify is used for PR previews and build badge)
 
+## Contribution Rules
+
+- We work only with PRs. 
+- The changes that do not need a special meeting are: 
+  - Link updates
+  - Typo corrections
+  - Adding a single item to a list (devtools, TFs, events). 
+- Adding or removing pages, adding or removing paragraphs or changing significant part of paragraphs need a special meeting.
+- The PRs should have the corresponding labels: needs-WG-review, time-critical (for bringing to main call), minor (editorial, technical and trivial changes). If the type of PR needed is clear from the issue, these labels can be also used in an issue.
+
 ## Testing site locally
 
 We use Jekyll and Bundler to develop this webpage.


### PR DESCRIPTION
Based on the discussion at https://www.w3.org/2022/12/06-wot-marketing-minutes.html , I have put these in the docs readme. Generally, a CONTRIBUTING.md is used in the root level but that is generally a W3C template (IPR etc.) whereas this is really our TF-specific rules. I am open for putting this in another place but trying to find the minutes is quite annoying so anywhere somewhat easy to find is fine by me.