### PR TITLE
Twitter via Plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 docs/.jekyll-cache/*
 docs/.bundle
+docs/.tweet-cache

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -7,3 +7,5 @@ source "https://rubygems.org"
 gem "webrick", "~> 1.7"
 
 gem "jekyll", "~> 4.2"
+
+gem "jekyll-twitter-plugin", "~> 2.1"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
     ffi (1.15.5)
-    ffi (1.15.5-x64-mingw-ucrt)
+    ffi (1.15.5-x64-unknown)
     forwardable-extended (2.6.0)
     http_parser.rb (0.8.0)
     i18n (1.8.11)
@@ -32,6 +32,7 @@ GEM
       terminal-table (~> 2.0)
     jekyll-sass-converter (2.1.0)
       sassc (> 2.0.1, < 3.0)
+    jekyll-twitter-plugin (2.1.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     kramdown (2.3.1)
@@ -60,12 +61,14 @@ GEM
     webrick (1.7.0)
 
 PLATFORMS
-  x64-mingw-ucrt
+  universal-darwin-22
+  x64-unknown
   x86_64-linux
 
 DEPENDENCIES
   jekyll (~> 4.2)
+  jekyll-twitter-plugin (~> 2.1)
   webrick (~> 1.7)
 
 BUNDLED WITH
-   2.3.6
+   2.3.19

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,6 +8,7 @@ url: "https://www.w3.org"
 baseurl: "/WoT"
 github_username: "w3c"
 git_repo: "wot-marketing"
+plugins: ['jekyll-twitter-plugin']
 
 navigation:
  - title: Groups

--- a/docs/index.html
+++ b/docs/index.html
@@ -87,9 +87,9 @@ title: Home
 	
 	</div>
 	<div class="col-md-4">
-		<a class="twitter-timeline" data-height="450" href="https://twitter.com/w3c_wot">Tweets by w3c_wot</a>
-		<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+		{% twitter https://twitter.com/w3c_wot maxheight=450 limit=5 %}
 	</div>
+	
 	</div>
 	
 	<!--
@@ -98,3 +98,5 @@ title: Home
 	</div>
 	-->
 </div>
+
+


### PR DESCRIPTION
This uses https://github.com/rob-murray/jekyll-twitter-plugin and sadly I see the exact same result. It is even doing the same thing underneath:
```html
	<div class="col-md-4">
		<div class='jekyll-twitter-plugin'><a class="twitter-timeline" data-height="450" data-tweet-limit="5" href="https://twitter.com/W3C_WoT?ref_src=twsrc%5Etfw">Tweets by W3C_WoT</a>
       <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
</div>
```