### PR TITLE
Video ordering

### DIFF
--- a/docs/videos/index.html
+++ b/docs/videos/index.html
@@ -5,7 +5,10 @@ group: "navigation"
 ---
 <div>
     <h2>WoT Videos</h2>
-    <p>Please find below a list of videos in the context of Web of Things (WoT).</p>
+    <p>
+        Please find below a list of videos in the context of Web of Things (WoT).
+        The videos are categorized based on the event types and sorted reverse chronologically.
+    </p>
 
     <br />
     <h3>Introduction</h3>

--- a/docs/videos/index.html
+++ b/docs/videos/index.html
@@ -7,7 +7,6 @@ group: "navigation"
     <h2>WoT Videos</h2>
     <p>
         Please find below a list of videos in the context of Web of Things (WoT).
-        The videos are categorized based on the event types and sorted reverse chronologically.
     </p>
 
     <br />

--- a/docs/videos/index.html
+++ b/docs/videos/index.html
@@ -71,26 +71,23 @@ group: "navigation"
             </a>
         </div>
         <div class="col-md-6">
-            <a target="_blank" href="https://www.youtube.com/watch?v=lt_P2BU8e3I">
-                <img class="img-responsive"
-                    style="min-width: 180px; width: 100%; border-width: thin; border-style: solid;"
-                    src="{{'/images/video-short-intro-robot-arm.png' | absolute_url }}"
-                    alt="Short Introduction - Robot Arm" />
-                <h4>Short Introduction to Web of Things
-            </a></h4>
-            <!-- 2019-10-16 -->
+            <a target="_blank" href="https://www.youtube.com/watch?v=bPxIfZo7jns">
+                <img class="img-responsive" style="min-width: 180px; width: 100%; border-width: thin; border-style: solid;"
+                    src="{{'/images/video-thumbnail-wam.png' | absolute_url }}" alt="WAM Video" />
+                <h4>Building a WoT application: WoT application Manager and TD-code</h4>
+                <!-- 2020-9-18 -->
             </a>
         </div>
     </div>
     <br /><br />
     <div class="row">
         <div class="col-md-6">
-            <a target="_blank" href="https://www.youtube.com/watch?v=bPxIfZo7jns">
-                <img class="img-responsive"
-                    style="min-width: 180px; width: 100%; border-width: thin; border-style: solid;"
-                    src="{{'/images/video-thumbnail-wam.png' | absolute_url }}" alt="WAM Video" />
-                <h4>Building a WoT application: WoT application Manager and TD-code</h4>
-                <!-- 2020-9-18 -->
+            <a target="_blank" href="https://www.youtube.com/watch?v=lt_P2BU8e3I">
+                <img class="img-responsive" style="min-width: 180px; width: 100%; border-width: thin; border-style: solid;"
+                    src="{{'/images/video-short-intro-robot-arm.png' | absolute_url }}" alt="Short Introduction - Robot Arm" />
+                <h4>Short Introduction to Web of Things
+            </a></h4>
+            <!-- 2019-10-16 -->
             </a>
         </div>
     </div>


### PR DESCRIPTION
fixes #361 

However, we should keep the explainer video on the top no matter what other intro video comes later on.