### PR TITLE
W3C Calendar with fullcalendar library

### DIFF
--- a/docs/activities/meetings/index.html
+++ b/docs/activities/meetings/index.html
@@ -5,70 +5,129 @@ group: "navigation"
 ---
 <div>
     <h2>W3C WoT – Web Conference Meetings</h2>
-    
+
+<!-- include moment and one of the moment-timezone builds -->
+<script src='https://cdn.jsdelivr.net/npm/moment@2.29.4/min/moment.min.js'></script>
+<script src='https://cdn.jsdelivr.net/npm/moment-timezone@0.5.40/builds/moment-timezone-with-data.min.js'></script>
+
+<!-- fullcalendar bundle -->
+<script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
+
+<!-- fullcalendar iCAL -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/ical.js/1.5.0/ical.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@fullcalendar/icalendar@6.1.8/index.global.min.js"></script>
+
+<!-- the connector. must go AFTER moment-timezone -->
+<script src='https://cdn.jsdelivr.net/npm/@fullcalendar/moment-timezone@6.1.8/index.global.min.js'></script>
+
 <script>
-function initTimezone() {
-    var tz = "UTC"; // default
-    // try to autodetect
-    var myDate = new Date();
-    var diffInMinutes = myDate.getTimezoneOffset();
-    console.log(diffInMinutes)
-    if (diffInMinutes) {
-        switch(diffInMinutes) {
-            case 480:
-                tz = "UTC-8";
-            case 420:
-                tz = "UTC-7";
-            case 300:
-                tz = "UTC-5";
-            case 240:
-                tz = "UTC-4";
-            case 180:
-                tz = "UTC-3";
-                break;
-            case 0:
-                tz = "UTC+0";
-                break;
-            case -60:
-                tz = "UTC+1";
-                break;
-            case -120:
-                tz = "UTC+2";
-                break;
-            case -180:
-                tz = "UTC+3";
-                break;
-            case -480:
-                tz = "UTC+8";
-                break;
-            case -540:
-                tz = "UTC+9";
-                break;
-        }
-    }
-    document.getElementById("timezoneSelect").value = tz;
-}
-function updateTimezone() {
-  var selVal = document.getElementById("timezoneSelect").value;
-  
-  // hide "all"
-  document.getElementById("UTC-7").style.display = 'none';
-//   document.getElementById("UTC-5").style.display = 'none';
-  document.getElementById("UTC-4").style.display = 'none';
-//   document.getElementById("UTC").style.display = 'none';
-  document.getElementById("UTC+1").style.display = 'none';
-  document.getElementById("UTC+2").style.display = 'none';
-  document.getElementById("UTC+3").style.display = 'none';
-  document.getElementById("UTC+8").style.display = 'none';
-  document.getElementById("UTC+9").style.display = 'none';
-  
-  // set the selected one visible
-  if (document.getElementById(selVal)) {
-    document.getElementById(selVal).style.display = '';
-  } else {
-    document.getElementById("UTC").style.display = ''; // default
-  }
-}
+	var icsEvents = [];
+
+	document.addEventListener('DOMContentLoaded', function() {
+		var timeZoneSelectorEl = document.getElementById("timezone_selector");
+		var calendarEl = document.getElementById('calendar');
+		var initialTimeZone = "America/New_York";
+		var todayDate = moment().startOf("day");
+		var YM = todayDate.format("YYYY-MM");
+		var YESTERDAY = todayDate.clone().subtract(1, "day").format("YYYY-MM-DD");
+		var TODAY = todayDate.format("YYYY-MM-DD");
+		var TOMORROW = todayDate.clone().add(1, "day").format("YYYY-MM-DD");
+		
+		var calendar = new FullCalendar.Calendar(calendarEl, {
+			timeZone: initialTimeZone, // 'Europe/Moscow',  'local' the default (unnecessary to specify)
+			headerToolbar: {
+				left: "prev,next today",
+				center: "title",
+				right: "dayGridMonth,timeGridWeek,timeGridDay,listWeek"
+			},
+			initialView: "timeGridWeek", // dayGridMonth, dayGridWeek, dayGridDay 
+			initialDate: TODAY,
+
+			navLinks: true, // can click day/week names to navigate views
+			editable: true,
+			selectable: true,
+			dayMaxEvents: true, // allow "more" link when too many events
+			events: {
+				url: 'localCopy.ics',
+				// url: 'https://www.w3.org/groups/ig/wot/calendar/export',
+				format: 'ics'
+			},
+			/* events: [
+				{
+				  title  : 'event3',
+				  start  : '2023-05-31T12:30:00',
+				  end    : '2023-05-31T14:30:00',
+				  allDay : false // will make the time show
+				}
+			  ], */
+			eventTimeFormat: { hour: "numeric", minute: "2-digit" }, // timeZoneName: "short"
+			dateClick: function(arg) {
+				console.log(arg.date.toUTCString()); // use *UTC* methods on the native Date Object
+				// will output something like 'Sat, 01 Sep 2018 00:00:00 GMT'
+
+			}
+		});
+
+		calendar.on('dateClick', function(info) {
+		  console.log('clicked on ' + info.dateStr);
+		});
+
+		calendar.render();
+
+		// Timezone Changer
+		// Idea w.r.t. timezone taken from https://preview.keenthemes.com/html/metronic/docs/general/fullcalendar/timezone
+
+		// TODO collect events once loaded, there MUST be an event/callback for it!?!?!
+		setTimeout(()=> {
+			calendar.getEvents().forEach(event => {
+				icsEvents.push(event);
+				console.log(JSON.stringify(event));
+			});
+		}, 1000);
+		
+		// when the timezone selector changes, dynamically change the calendar option
+		$(timeZoneSelectorEl).on("change", function () {
+			// calendar.setOption("timeZone", "UTC");
+			// calendar.setOption("timeZone", "America/New_York");
+			var localTimezoneOffset = new Date().getTimezoneOffset(); // in minutes e.g, -120
+			let diff = Number(this.value) + localTimezoneOffset;
+
+			// Remove all events
+			const removeEvents = calendar.getEvents();
+			removeEvents.forEach(event => {
+				// console.log("" +  JSON.stringify(event));
+				event.remove();
+			});
+
+			const format = "YYYY-MM-DDTHH:mm:ss";
+
+			// Add events with new timezone offset
+			icsEvents.forEach(event => {
+				var start;
+				var end;
+				
+				let ms = moment(event.start); // reports local time
+				let me = moment(event.end); // reports local time
+				
+				start = ms.add(diff, "minutes").format(format);
+				if (me) {
+					end = me.add(diff, "minutes").format(format);
+				}
+				
+				// TODO add repeat etc (does not work as expected) --> copy ?!?
+				calendar.addEvent({
+					title: event.title,
+					start: start,
+					end: end,
+					// extendedProps: event.extendedProps
+				});
+			});
+
+			calendar.render();
+		});
+		
+		
+	});
 </script>
     <!-- <div class="alert alert-warning" role="alert">
       Note: Most calls during August, due to summer vacations, will be <a href="https://www.w3.org/WoT/IG/wiki/Main_WoT_WebConf#Cancellations">cancelled</a>.
@@ -78,208 +137,22 @@ function updateTimezone() {
                     href="https://www.w3.org/groups/ig/wot/calendar" target="_blank">the W3C calendar system</a> in order to download 
         ICS files for all our meetings. 
     </p>
-    <p>Select Timezone: 
-        <select id="timezoneSelect" class="browser-default custom-select" onchange="updateTimezone();">
-          <option value="UTC-7"> US Pacific (PDT) UTC-7</option>
-          <option value="UTC-4">US Eastern (EDT) UTC-4</option>
-          <!-- <option value="UTC-4">Atlantic (AST) UTC-4</option> -->
-          <!-- <option value="UTC" selected="selected">UTC</option> -->
-          <option value="UTC+1">UK (GMT+1) UTC+1</option>
-          <option value="UTC+2">EU (CEST) UTC+2</option>
-          <option value="UTC+3">Finland (EEST) UTC+3</option>
-          <option value="UTC+8">Singapore (SGT) China (CST) UTC+8</option>
-          <option value="UTC+9">Korea (KST) Japan (JST) UTC+9</option>
-        </select>
-    </p>
-    <table style="display: table; border-collapse: separate; border-spacing: 1px; border-color: gray;  width: 100%">
-
-        <tbody>
-        <tr id="UTC-7">
-            <th style="background-color: #DEEEEE; text-align:center;">US Pacific<br>(PDT)<br>UTC-7</th>
-            <td style="background-color: #EEEEEE; text-align:center;">3:00 - 4:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">4:00 - 5:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">5:00 - 6:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">6:00 - 7:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">7:00 - 8:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">8:00 - 9:00</td>
-        </tr>
-
-        <tr id="UTC-4">
-            <th style="background-color: #DEEEEE; text-align:center;">US Eastern<br>(EDT)<br>UTC-4</th>
-            <td style="background-color: #EEEEEE; text-align:center;">6:00 - 7:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">7:00 - 8:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">8:00 - 9:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">9:00 - 10:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">10:00 - 11:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">11:00 - 12:00</td>
-        </tr>
-
-        <!-- <tr id="UTC-4">
-            <th style="background-color: #DEEEEE; text-align:center;">Atlantic<br>(AST)<br>UTC-4</th>
-            <td style="background-color: #EEEEEE; text-align:center;">7:00 - 8:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">8:00 - 9:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">9:00 - 10:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">10:00 - 11:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">11:00 - 12:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">12:00 - 13:00</td>
-        </tr> -->
-
-        <tr id="UTC+1">
-            <th style="background-color: #DEEEEE; text-align:center;">UK (GMT)<br>UTC+1<br></th>
-            <!-- <td style="background-color: #EEEEEE; text-align:center;">10:00 - 11:00</td> -->
-            <td style="background-color: #EEEEEE; text-align:center;">11:00 - 12:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">12:00 - 13:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">13:00 - 14:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">14:00 - 15:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">15:00 - 16:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">16:00 - 17:00</td>
-        </tr>
-
-        <tr id="UTC+2">
-            <th style="background-color: #DEEEEE; text-align:center;">EU (CEST)<br>UTC+2<br></th>
-            <!-- <td style="background-color: #EEEEEE; text-align:center;">11:00 - 12:00</td> -->
-            <td style="background-color: #EEEEEE; text-align:center;">12:00 - 13:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">13:00 - 14:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">14:00 - 15:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">15:00 - 16:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">16:00 - 17:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">17:00 - 18:00</td>
-        </tr>
-
-        <tr id="UTC+3">
-            <th style="background-color: #DEEEEE; text-align:center;">Finland (EEST)<br>UTC+3<br></th>
-            <!-- <td style="background-color: #EEEEEE; text-align:center;">12:00 - 13:00</td> -->
-            <td style="background-color: #EEEEEE; text-align:center;">13:00 - 14:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">14:00 - 15:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">15:00 - 16:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">16:00 - 17:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">17:00 - 18:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">18:00 - 19:00</td>
-        </tr>
-
-        <!-- <tr id="UTC+3">
-            <th style="background-color: #DEEEEE; text-align:center;">&nbsp;<br>UTC+3<br>&nbsp;</th>
-            <td style="background-color: #EEEEEE; text-align:center;">13:00 - 14:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">14:00 - 15:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">15:00 - 16:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">16:00 - 17:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">17:00 - 18:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">18:00 - 19:00</td>
-        </tr> -->
-
-        <tr id="UTC+8">
-            <th style="background-color: #DEEEEE; text-align:center;">Singapore (SGT)<br>China (CST)<br>UTC+8</th>
-            <td style="background-color: #EEEEEE; text-align:center;">18:00 - 19:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">19:00 - 20:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">20:00 - 21:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">21:00 - 22:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">22:00 - 23:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">23:00 - 24:00</td>
-            <!-- <td style="background-color: #EEEEEE; text-align:center;">24:00 - 25:00</td> -->
-        </tr>
-
-        <tr id="UTC+9">
-            <th style="background-color: #DEEEEE; text-align:center;">Korea (KST)<br>Japan (JST)<br>UTC+9</th>
-            <td style="background-color: #EEEEEE; text-align:center;">19:00 - 20:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">20:00 - 21:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">21:00 - 22:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">22:00 - 23:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">23:00 - 24:00</td>
-            <td style="background-color: #EEEEEE; text-align:center;">24:00 - 25:00</td>
-            <!-- <td style="background-color: #EEEEEE; text-align:center;">25:00 - 26:00</td> -->
-        </tr>
-
-        <tr>
-            <th style="background-color: #FEFEEE; text-align:center;">Mon</th>
-            <td style="text-align:center;">-</td>
-            <td style="background-color: #FEEEDD; text-align:center;"><a rel="nofollow" class="external text"
-                    href="https://www.w3.org/WoT/IG/wiki/WG_WoT_Scripting_API_WebConf" target="_blank">WoT Scripting API</a><br><a rel="nofollow"
-                    class="external text" href="https://lists.w3.org/Archives/Member/member-wot-wg/2018Feb/0033.html" target="_blank">(WebEx)</a>
-            </td>
-            <td style="background-color: #FEEEAA; text-align:center;"><a rel="nofollow" class="external text"
-                    href="https://www.w3.org/WoT/IG/wiki/IG_Security_WebConf" target="_blank">WoT Security</a><br><a rel="nofollow"
-                    class="external text" href="https://lists.w3.org/Archives/Member/member-wot-wg/2019Nov/0006.html" target="_blank">(WebEx)</a>
-            </td>
-            <td style="text-align:center;">-</td>
-            <td style="background-color: #FEEEDD; text-align:center;"><a rel="nofollow" class="external text"
-                    href="https://www.w3.org/WoT/IG/wiki/WG_WoT_Discovery_WebConf" target="_blank">WoT Discovery</a><br><a rel="nofollow"
-                    class="external text" href="https://lists.w3.org/Archives/Member/member-wot-wg/2020Feb/0009.html" target="_blank">(WebEx)</a>
-            </td>
-            <td style="text-align:center;">-</td>
-        </tr>
-
-		<tr>
-			<th style="background-color: #FEFEEE; text-align:center;">Tue</th>
-			<td style="background-color: #FEFEDD; text-align:center;"><br></td>
-			<td style="background-color: #FEEEAA; text-align:center;"><a rel="nofollow" class="external text"
-					href="https://www.w3.org/WoT/IG/wiki/Marketing_WebConf" target="_blank">WoT Marketing</a><br><a rel="nofollow"
-					class="external text" href="https://lists.w3.org/Archives/Member/member-wot-wg/2020Aug/0024.html" target="_blank">(WebEx)</a>
-			</td>
-			<td style="background-color: #FEEEAA; text-align:center;">WoT Use Cases<br> <a rel="nofollow"
-					class="external text" href="https://lists.w3.org/Archives/Member/member-wot-wg/2022Dec/0003.html" target="_blank">(WebEx)</a>
-			</td>
-			<td style="text-align:center;">-</td>
-			<td style="text-align:center;">-</td>
-			<td style="text-align:center;">-</td>
-		</tr>
-
-
-        <tr>
-            <th style="background-color: #FEFEEE; text-align:center;">Wed</th>
-            <td style="background-color: #FEFEDD; text-align:center;">WoT Chairs<br><a rel="nofollow" class="external text"
-                    href="https://lists.w3.org/Archives/Member/member-wot-wg/2019May/0007.html" target="_blank">(WebEx)</a></td>
-            <td style="background-color: #FEEEDD; text-align:center;"><a rel="nofollow" class="external text"
-                    href="https://www.w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf" target="_blank">WoT Profiles</a><br><a rel="nofollow"
-                    class="external text" href="https://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0006.html" target="_blank">(WebEx)</a>
-            </td>
-            <td style="background-color: #FEFE77; text-align:center;"><a rel="nofollow" class="external text"
-                    href="https://www.w3.org/WoT/IG/wiki/Main_WoT_WebConf" target="_blank">WoT IG/WG main call</a><br><a rel="nofollow"
-                    class="external text" href="https://lists.w3.org/Archives/Member/member-wot-wg/2020Jul/0052.html" target="_blank">(WebEx)</a>
-            </td>
-            <td style="background-color: #FEEEAA; text-align:center;"><a rel="nofollow" class="external text"
-                    href="https://www.w3.org/WoT/IG/wiki/PlugFest_WebConf" target="_blank">WoT PlugFest</a><br><a rel="nofollow"
-                    class="external text" href="https://lists.w3.org/Archives/Member/member-wot-wg/2020Jul/0052.html" target="_blank">(WebEx)</a>
-            </td>
-            <td style="background-color: #FEEEDD; text-align:center;" colspan="2"><a rel="nofollow" class="external text"
-                    href="https://www.w3.org/WoT/IG/wiki/WG_WoT_Thing_Description_WebConf" target="_blank">WoT TD / Binding Templates (2h)</a><br><a
-                    rel="nofollow" class="external text"
-                    href="https://lists.w3.org/Archives/Member/member-wot-wg/2020Jul/0027.html" target="_blank">(WebEx)</a></td>
-        </tr>
-
-        <tr>
-            <th style="background-color: #FEFEEE; text-align:center;">Thu</th>
-            <td style="background-color: #FEEEDD; text-align:center;"><a rel="nofollow" class="external text"
-                    href="https://www.w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf" target="_blank">WoT Architecture</a><br><a rel="nofollow"
-                    class="external text" href="https://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0007.html" target="_blank">(WebEx)</a>
-            </td>
-            <td style="text-align:center;">-</td>
-            <td style="text-align:center;">-</td>
-            <td style="text-align:center;">-</td>
-            <td style="text-align:center;">-</td>
-            <td style="text-align:center;">-</td>
-        </tr>
-
-        <tr>
-            <th style="background-color: #FEFEEE; text-align:center;">Fri</th>
-            <td style="text-align:center;">-</td>
-            <td style="text-align:center;">-</td>
-            <td style="text-align:center;">-</td>
-            <td style="text-align:center;">-</td>
-            <td style="text-align:center;">-</td>
-            <td style="text-align:center;">-</td>
-        </tr>
-    </tbody></table>
-    
-    <h4>Color legend:</h4>
-        <ul><li> <span style="background-color: #FEEEDD">&nbsp;WoT WG calls&nbsp;</span></li>
-        <li> <span style="background-color: #FEEEAA">&nbsp;WoT IG calls&nbsp;</span></li>
-        <li> <span style="background-color: #FEFE77">&nbsp;WoT IG/WG joint call&nbsp;</span></li>
-        <li> <span style="background-color: #FEFEDD">&nbsp;WoT Chairs call&nbsp;</span></li>
-    </ul>
+	
+	<!--begin::Localization dropdown-->
+	<div class="mb-5">
+		<label class="fs-4 fw-bold mb-3">Select a Timezone:</label>
+		<select id="timezone_selector" class="form-select mw-200px" data-control="select2" data-placeholder="Select an option">
+			<option value="-240">US Eastern</option><!-- -4 -->
+			<option value="0">(GMT) UTC</option>
+			<option value="120">CEST</option><!-- +2 -->
+		</select>
+	</div>
+	<!--end::Localization dropdown-->
+	
+	<div id='calendar'></div>
     
 <script>
-initTimezone();
-updateTimezone();
+// 
 </script>
     
     

--- a/docs/activities/meetings/index.html
+++ b/docs/activities/meetings/index.html
@@ -49,6 +49,7 @@ group: "navigation"
 			// navLinks: true, // can click day/week names to navigate views
 			editable: false,
 			selectable: true,
+			weekends: false,
 			// dayMaxEvents: true, // allow "more" link when too many events
 			events: {
 				url: 'localCopy.ics',

--- a/docs/activities/meetings/index.html
+++ b/docs/activities/meetings/index.html
@@ -64,7 +64,14 @@ group: "navigation"
 			dateClick: function(arg) {
 				console.log(arg.date.toUTCString()); // use *UTC* methods on the native Date Object
 				// will output something like 'Sat, 01 Sep 2018 00:00:00 GMT'
-
+			},
+			loading: function (isLoading) {
+				if (isLoading) {
+					// loading...
+				} else {
+					console.log("loading DONE, collect events !!!!!!!");
+					initIcsEvents(calendar);
+				}
 			}
 		});
 
@@ -76,14 +83,6 @@ group: "navigation"
 
 		// Timezone Changer
 		// Idea w.r.t. timezone taken from https://preview.keenthemes.com/html/metronic/docs/general/fullcalendar/timezone
-
-		// TODO collect events once loaded, there MUST be an event/callback for it!?!?!
-		setTimeout(()=> {
-			calendar.getEvents().forEach(event => {
-				icsEvents.push(event);
-				console.log(JSON.stringify(event));
-			});
-		}, 1000);
 		
 		// when the timezone selector changes, dynamically change the calendar option
 		$(timeZoneSelectorEl).on("change", function () {
@@ -127,6 +126,16 @@ group: "navigation"
 		
 		
 	});
+	
+	function initIcsEvents(calendar) {
+		console.log("Init ICS list");
+		setTimeout(()=> {
+			calendar.getEvents().forEach(event => {
+				icsEvents.push(event);
+				console.log(JSON.stringify(event));
+			});
+		}, 100);
+	}
 </script>
     <!-- <div class="alert alert-warning" role="alert">
       Note: Most calls during August, due to summer vacations, will be <a href="https://www.w3.org/WoT/IG/wiki/Main_WoT_WebConf#Cancellations">cancelled</a>.

--- a/docs/activities/meetings/index.html
+++ b/docs/activities/meetings/index.html
@@ -64,11 +64,24 @@ group: "navigation"
 				  allDay : false // will make the time show
 				}
 			  ], */
-			eventTimeFormat: { hour: "numeric", minute: "2-digit" }, // timeZoneName: "short"
+			// eventTimeFormat: { hour: "numeric", minute: "2-digit" }, // timeZoneName: "short"
 			dateClick: function(arg) {
 				console.log(arg.date.toUTCString()); // use *UTC* methods on the native Date Object
 				// will output something like 'Sat, 01 Sep 2018 00:00:00 GMT'
 			},
+			eventClick: function(data, event, view) {
+				// $('[data-toggle="popover"]').popover();
+				/* var content = '<h3>'+data.title+'</h3>' + 
+					'<p><b>Start:</b> '+data.start+'<br />' + 
+					(data.end && '<p><b>End:</b> '+data.end+'</p>' || '');
+				tooltip.set({
+					'content.text': content
+				})
+				.reposition(event).show(event); */
+			},
+			/* eventRender: function (info) {
+			  $(info.el).tooltip({ title: info.event.title });     
+			}, */
 			loading: function (isLoading) {
 				if (isLoading) {
 					// loading...
@@ -76,7 +89,7 @@ group: "navigation"
 					console.log("loading DONE, collect events !!!!!!!");
 					initIcsEvents(calendar);
 				}
-			}
+			},
 		});
 
 		calendar.on('dateClick', function(info) {

--- a/docs/activities/meetings/index.html
+++ b/docs/activities/meetings/index.html
@@ -22,11 +22,11 @@ group: "navigation"
 
 <script>
 	var icsEvents = [];
+	var initialTimeZone = "America/New_York";
 
 	document.addEventListener('DOMContentLoaded', function() {
 		var timeZoneSelectorEl = document.getElementById("timezone_selector");
 		var calendarEl = document.getElementById('calendar');
-		var initialTimeZone = "America/New_York";
 		var todayDate = moment().startOf("day");
 		var YM = todayDate.format("YYYY-MM");
 		var YESTERDAY = todayDate.clone().subtract(1, "day").format("YYYY-MM-DD");
@@ -44,7 +44,7 @@ group: "navigation"
 			initialDate: TODAY,
 
 			navLinks: true, // can click day/week names to navigate views
-			editable: true,
+			editable: false,
 			selectable: true,
 			dayMaxEvents: true, // allow "more" link when too many events
 			events: {
@@ -90,11 +90,11 @@ group: "navigation"
 			// calendar.setOption("timeZone", "UTC");
 			// calendar.setOption("timeZone", "America/New_York");
 			var localTimezoneOffset = new Date().getTimezoneOffset(); // in minutes e.g, -120
-			let diff = Number(this.value) + localTimezoneOffset;
+			// let diff = Number(this.value) + localTimezoneOffset;
+			let newTZ = this.value;
 
-			// Remove all events
-			const removeEvents = calendar.getEvents();
-			removeEvents.forEach(event => {
+			// update all events
+			calendar.getEvents().forEach(event => {
 				// console.log("" +  JSON.stringify(event));
 				event.remove();
 			});
@@ -103,15 +103,14 @@ group: "navigation"
 
 			// Add events with new timezone offset
 			icsEvents.forEach(event => {
-				var start;
+				let localTZ = Intl.DateTimeFormat().resolvedOptions().timeZone;
+				let ms = moment.tz(event.start, localTZ); // initialTimeZone); // reports local time
+				let me = moment.tz(event.end, localTZ); // initialTimeZone); // reports local time
+				
+				var start = ms.clone().tz(newTZ).format(format); // ms.add(diff, "minutes").format(format);
 				var end;
-				
-				let ms = moment(event.start); // reports local time
-				let me = moment(event.end); // reports local time
-				
-				start = ms.add(diff, "minutes").format(format);
 				if (me) {
-					end = me.add(diff, "minutes").format(format);
+					end = me.clone().tz(newTZ).format(format); // me.add(diff, "minutes").format(format);
 				}
 				
 				// TODO add repeat etc (does not work as expected) --> copy ?!?
@@ -142,9 +141,16 @@ group: "navigation"
 	<div class="mb-5">
 		<label class="fs-4 fw-bold mb-3">Select a Timezone:</label>
 		<select id="timezone_selector" class="form-select mw-200px" data-control="select2" data-placeholder="Select an option">
-			<option value="-240">US Eastern</option><!-- -4 -->
-			<option value="0">(GMT) UTC</option>
-			<option value="120">CEST</option><!-- +2 -->
+			<option value="America/New_York"     >America/New_York</option>
+			<option value="America/Los_Angeles" >America/Los_Angeles</option>
+			<option value="UTC"                  >UTC</option>
+			<option value="Europe/London"        >Europe/London</option>
+			<option value="Europe/Paris"         >Europe/Paris</option>
+			<option value="Europe/Helsinki"      >Europe/Helsinki</option>
+			<option value="Asia/Singapore"       >Asia/Singapore</option>
+			<option value="Asia/Tokyo"           >Asia/Tokyo</option>
+			
+			
 		</select>
 	</div>
 	<!--end::Localization dropdown-->

--- a/docs/activities/meetings/index.html
+++ b/docs/activities/meetings/index.html
@@ -29,24 +29,27 @@ group: "navigation"
 		var calendarEl = document.getElementById('calendar');
 		var todayDate = moment().startOf("day");
 		var YM = todayDate.format("YYYY-MM");
-		var YESTERDAY = todayDate.clone().subtract(1, "day").format("YYYY-MM-DD");
+		// var YESTERDAY = todayDate.clone().subtract(1, "day").format("YYYY-MM-DD");
 		var TODAY = todayDate.format("YYYY-MM-DD");
-		var TOMORROW = todayDate.clone().add(1, "day").format("YYYY-MM-DD");
+		// var TOMORROW = todayDate.clone().add(1, "day").format("YYYY-MM-DD");
 		
 		var calendar = new FullCalendar.Calendar(calendarEl, {
 			timeZone: initialTimeZone, // 'Europe/Moscow',  'local' the default (unnecessary to specify)
 			headerToolbar: {
-				left: "prev,next today",
-				center: "title",
-				right: "dayGridMonth,timeGridWeek,timeGridDay,listWeek"
+				// left: "prev,next today",
+				// center: "title",
+				// right: "timeGridWeek,timeGridDay,listWeek" // dayGridMonth,
 			},
 			initialView: "timeGridWeek", // dayGridMonth, dayGridWeek, dayGridDay 
 			initialDate: TODAY,
-
-			navLinks: true, // can click day/week names to navigate views
+			/* validRange: {
+				start: '2023-05-29',
+				end: '2023-06-03'
+			}, */
+			// navLinks: true, // can click day/week names to navigate views
 			editable: false,
 			selectable: true,
-			dayMaxEvents: true, // allow "more" link when too many events
+			// dayMaxEvents: true, // allow "more" link when too many events
 			events: {
 				url: 'localCopy.ics',
 				// url: 'https://www.w3.org/groups/ig/wot/calendar/export',
@@ -103,6 +106,7 @@ group: "navigation"
 			// Add events with new timezone offset
 			icsEvents.forEach(event => {
 				let localTZ = Intl.DateTimeFormat().resolvedOptions().timeZone;
+				// see https://momentjs.com/timezone/ or https://momentjs.com/timezone/docs/
 				let ms = moment.tz(event.start, localTZ); // initialTimeZone); // reports local time
 				let me = moment.tz(event.end, localTZ); // initialTimeZone); // reports local time
 				

--- a/docs/activities/meetings/index.html
+++ b/docs/activities/meetings/index.html
@@ -141,14 +141,14 @@ group: "navigation"
 	<div class="mb-5">
 		<label class="fs-4 fw-bold mb-3">Select a Timezone:</label>
 		<select id="timezone_selector" class="form-select mw-200px" data-control="select2" data-placeholder="Select an option">
-			<option value="America/New_York"     >America/New_York</option>
-			<option value="America/Los_Angeles" >America/Los_Angeles</option>
-			<option value="UTC"                  >UTC</option>
-			<option value="Europe/London"        >Europe/London</option>
-			<option value="Europe/Paris"         >Europe/Paris</option>
-			<option value="Europe/Helsinki"      >Europe/Helsinki</option>
-			<option value="Asia/Singapore"       >Asia/Singapore</option>
-			<option value="Asia/Tokyo"           >Asia/Tokyo</option>
+			<option value="America/Los_Angeles"                  >America/Los_Angeles</option>
+			<option value="America/New_York" selected="selected" >America/New_York</option>
+			<option value="UTC"                                  >UTC</option>
+			<option value="Europe/London"                        >Europe/London</option>
+			<option value="Europe/Paris"                         >Europe/Paris</option>
+			<option value="Europe/Helsinki"                      >Europe/Helsinki</option>
+			<option value="Asia/Singapore"                       >Asia/Singapore</option>
+			<option value="Asia/Tokyo"                           >Asia/Tokyo</option>
 			
 			
 		</select>

--- a/docs/activities/meetings/localCopy.ics
+++ b/docs/activities/meetings/localCopy.ics
@@ -1,0 +1,6119 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Sabre//Sabre VObject 4.5.3//EN
+CALSCALE:GREGORIAN
+NAME:Web of Things Interest Group Calendar
+X-WR-CALNAME:Web of Things Interest Group Calendar
+BEGIN:VTIMEZONE
+TZID:America/New_York
+X-MICROSOFT-CDO-TZID:10
+BEGIN:DAYLIGHT
+DTSTART:20210314T070000
+TZOFFSETFROM:-0500
+TZOFFSETTO:-0400
+TZNAME:EDT
+END:DAYLIGHT
+BEGIN:DAYLIGHT
+DTSTART:20220313T070000
+TZOFFSETFROM:-0500
+TZOFFSETTO:-0400
+TZNAME:EDT
+END:DAYLIGHT
+BEGIN:DAYLIGHT
+DTSTART:20230312T070000
+TZOFFSETFROM:-0500
+TZOFFSETTO:-0400
+TZNAME:EDT
+END:DAYLIGHT
+BEGIN:DAYLIGHT
+DTSTART:20240310T070000
+TZOFFSETFROM:-0500
+TZOFFSETTO:-0400
+TZNAME:EDT
+END:DAYLIGHT
+BEGIN:STANDARD
+DTSTART:20211107T060000
+TZOFFSETFROM:-0400
+TZOFFSETTO:-0500
+TZNAME:EST
+END:STANDARD
+BEGIN:STANDARD
+DTSTART:20221106T060000
+TZOFFSETFROM:-0400
+TZOFFSETTO:-0500
+TZNAME:EST
+END:STANDARD
+BEGIN:STANDARD
+DTSTART:20231105T060000
+TZOFFSETFROM:-0400
+TZOFFSETTO:-0500
+TZNAME:EST
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VTIMEZONE
+TZID:America/Vancouver
+BEGIN:STANDARD
+DTSTART:20211107T090000
+TZOFFSETFROM:-0700
+TZOFFSETTO:-0800
+TZNAME:PST
+END:STANDARD
+BEGIN:STANDARD
+DTSTART:20221106T090000
+TZOFFSETFROM:-0700
+TZOFFSETTO:-0800
+TZNAME:PST
+END:STANDARD
+BEGIN:DAYLIGHT
+DTSTART:20220313T100000
+TZOFFSETFROM:-0800
+TZOFFSETTO:-0700
+TZNAME:PDT
+END:DAYLIGHT
+END:VTIMEZONE
+BEGIN:VTIMEZONE
+TZID:Europe/Berlin
+X-MICROSOFT-CDO-TZID:4
+BEGIN:STANDARD
+DTSTART:20211031T010000
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+TZNAME:CET
+END:STANDARD
+BEGIN:STANDARD
+DTSTART:20221030T010000
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+TZNAME:CET
+END:STANDARD
+BEGIN:STANDARD
+DTSTART:20231029T010000
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+TZNAME:CET
+END:STANDARD
+BEGIN:DAYLIGHT
+DTSTART:20220327T010000
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0200
+TZNAME:CEST
+END:DAYLIGHT
+BEGIN:DAYLIGHT
+DTSTART:20230326T010000
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0200
+TZNAME:CEST
+END:DAYLIGHT
+END:VTIMEZONE
+BEGIN:VEVENT
+UID:4dafa7f0-678b-4474-93f4-8a56062f5ee8
+DTSTAMP:20220307T164059Z
+SUMMARY:WoT Main
+DTSTART;TZID=America/New_York:20220302T080000
+DTEND;TZID=America/New_York:20220302T090000
+DESCRIPTION:https://www.w3.org/events/meetings/4dafa7f0-678b-4474-93f4-8a56
+ 062f5ee8\n\nThe [Main WoT Web Conference](https://www.w3.org/WoT/IG/wiki/M
+ ain_WoT_WebConf) is a joint IG/WG call for discussing general WoT IG and W
+ G topics and logistics\, and to provide an opportunity to summarize and co
+ ordinate the activities of the various task forces. For information on ind
+ ividual task forces\, please see the [WoT Web Page](https://www.w3.org/WoT
+ /) or look at the other WoT schedule entries.\n\n[IRC: #wot](https://irc.w
+ 3.org/?channels=wot) / [WebEx](https://lists.w3.org/Archives/Member/member
+ -wot-wg/2020Jul/0052.html)
+STATUS:CONFIRMED
+CREATED:20220301T161516Z
+LAST-MODIFIED:20220307T164059Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RRULE:FREQ=WEEKLY;UNTIL=20220302T130000Z;INTERVAL=1;BYDAY=WE;WKST=MO
+RELATED-TO:18c35c2a-47d6-44fe-b198-e438256544f3
+END:VEVENT
+BEGIN:VEVENT
+UID:18c35c2a-47d6-44fe-b198-e438256544f3
+DTSTAMP:20230201T180548Z
+SUMMARY:WoT Main
+DTSTART;TZID=America/New_York:20220309T080000
+DTEND;TZID=America/New_York:20220309T090000
+DESCRIPTION:https://www.w3.org/events/meetings/18c35c2a-47d6-44fe-b198-e438
+ 256544f3\n\nThe [Main WoT Web Conference](https://www.w3.org/WoT/IG/wiki/M
+ ain_WoT_WebConf) is a joint IG/WG call for discussing general WoT IG and W
+ G topics and logistics\, and to provide an opportunity to summarize and co
+ ordinate the activities of the various task forces. For information on ind
+ ividual task forces\, please see the [WoT Web Page](https://www.w3.org/WoT
+ /) or look at the other WoT schedule entries.\n\n[IRC: #wot](https://irc.w
+ 3.org/?channels=wot) / [WebEx](https://lists.w3.org/Archives/Member/member
+ -wot-wg/2020Jul/0052.html)
+STATUS:CONFIRMED
+CREATED:20220307T164056Z
+LAST-MODIFIED:20230201T180548Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RELATED-TO:4dafa7f0-678b-4474-93f4-8a56062f5ee8
+RELATED-TO:d61fb100-18b4-405f-97f5-6a831866caa6
+RRULE:FREQ=WEEKLY;UNTIL=20230125T130000Z;INTERVAL=1;BYDAY=WE;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:18c35c2a-47d6-44fe-b198-e438256544f3
+DTSTAMP:20220831T161320Z
+SUMMARY:WoT Main
+DTSTART;TZID=America/New_York:20220907T080000
+DTEND;TZID=America/New_York:20220907T090000
+DESCRIPTION:https://www.w3.org/events/meetings/18c35c2a-47d6-44fe-b198-e438
+ 256544f3/20220907T080000\n\nThe [Main WoT Web Conference](https://www.w3.o
+ rg/WoT/IG/wiki/Main_WoT_WebConf) is a joint IG/WG call for discussing gene
+ ral WoT IG and WG topics and logistics\, and to provide an opportunity to 
+ summarize and coordinate the activities of the various task forces. For in
+ formation on individual task forces\, please see the [WoT Web Page](https:
+ //www.w3.org/WoT/) or look at the other WoT schedule entries.\n\n[IRC: #wo
+ t](https://irc.w3.org/?channels=wot) / [WebEx](https://lists.w3.org/Archiv
+ es/Member/member-wot-wg/2020Jul/0052.html)
+STATUS:CANCELLED
+CREATED:20220831T161319Z
+LAST-MODIFIED:20220831T161320Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220907T080000
+END:VEVENT
+BEGIN:VEVENT
+UID:18c35c2a-47d6-44fe-b198-e438256544f3
+DTSTAMP:20220831T162117Z
+SUMMARY:WoT Main
+DTSTART;TZID=America/New_York:20220914T080000
+DTEND;TZID=America/New_York:20220914T090000
+DESCRIPTION:https://www.w3.org/events/meetings/18c35c2a-47d6-44fe-b198-e438
+ 256544f3/20220914T080000\n\nThe [Main WoT Web Conference](https://www.w3.o
+ rg/WoT/IG/wiki/Main_WoT_WebConf) is a joint IG/WG call for discussing gene
+ ral WoT IG and WG topics and logistics\, and to provide an opportunity to 
+ summarize and coordinate the activities of the various task forces. For in
+ formation on individual task forces\, please see the [WoT Web Page](https:
+ //www.w3.org/WoT/) or look at the other WoT schedule entries.\n\n[IRC: #wo
+ t](https://irc.w3.org/?channels=wot) / [WebEx](https://lists.w3.org/Archiv
+ es/Member/member-wot-wg/2020Jul/0052.html)
+STATUS:CANCELLED
+CREATED:20220831T162115Z
+LAST-MODIFIED:20220831T162117Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220914T080000
+END:VEVENT
+BEGIN:VEVENT
+UID:18c35c2a-47d6-44fe-b198-e438256544f3
+DTSTAMP:20220919T152611Z
+SUMMARY:WoT Main
+DTSTART;TZID=America/New_York:20220921T080000
+DTEND;TZID=America/New_York:20220921T090000
+DESCRIPTION:https://www.w3.org/events/meetings/18c35c2a-47d6-44fe-b198-e438
+ 256544f3/20220921T080000\n\nThe [Main WoT Web Conference](https://www.w3.o
+ rg/WoT/IG/wiki/Main_WoT_WebConf) is a joint IG/WG call for discussing gene
+ ral WoT IG and WG topics and logistics\, and to provide an opportunity to 
+ summarize and coordinate the activities of the various task forces. For in
+ formation on individual task forces\, please see the [WoT Web Page](https:
+ //www.w3.org/WoT/) or look at the other WoT schedule entries.\n\n[IRC: #wo
+ t](https://irc.w3.org/?channels=wot) / [WebEx](https://lists.w3.org/Archiv
+ es/Member/member-wot-wg/2020Jul/0052.html)
+STATUS:CANCELLED
+CREATED:20220919T152609Z
+LAST-MODIFIED:20220919T152611Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220921T080000
+END:VEVENT
+BEGIN:VEVENT
+UID:18c35c2a-47d6-44fe-b198-e438256544f3
+DTSTAMP:20230111T112248Z
+SUMMARY:WoT Main
+DTSTART;TZID=America/New_York:20230118T080000
+DTEND;TZID=America/New_York:20230118T090000
+DESCRIPTION:https://www.w3.org/events/meetings/18c35c2a-47d6-44fe-b198-e438
+ 256544f3/20230118T080000\n\nThe [Main WoT Web Conference](https://www.w3.o
+ rg/WoT/IG/wiki/Main_WoT_WebConf) is a joint IG/WG call for discussing gene
+ ral WoT IG and WG topics and logistics\, and to provide an opportunity to 
+ summarize and coordinate the activities of the various task forces. For in
+ formation on individual task forces\, please see the [WoT Web Page](https:
+ //www.w3.org/WoT/) or look at the other WoT schedule entries.\n\n[IRC: #wo
+ t](https://irc.w3.org/?channels=wot) / [WebEx](https://lists.w3.org/Archiv
+ es/Member/member-wot-wg/2020Jul/0052.html)
+STATUS:CANCELLED
+CREATED:20230111T112247Z
+LAST-MODIFIED:20230111T112248Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20230118T080000
+END:VEVENT
+BEGIN:VEVENT
+UID:d61fb100-18b4-405f-97f5-6a831866caa6
+DTSTAMP:20230529T110716Z
+SUMMARY:WoT Main
+DTSTART;TZID=America/New_York:20230201T080000
+DTEND;TZID=America/New_York:20230201T090000
+DESCRIPTION:https://www.w3.org/events/meetings/d61fb100-18b4-405f-97f5-6a83
+ 1866caa6\n\nThe [Main WoT Web Conference](https://www.w3.org/WoT/IG/wiki/M
+ ain_WoT_WebConf) is a joint IG/WG call for discussing general WoT IG and W
+ G topics and logistics\, and to provide an opportunity to summarize and co
+ ordinate the activities of the various task forces. For information on ind
+ ividual task forces\, please see the [WoT Web Page](https://www.w3.org/WoT
+ /) or look at the other WoT schedule entries.\n\n[IRC: #wot](https://irc.w
+ 3.org/?channels=wot) / [WebEx](https://lists.w3.org/Archives/Member/member
+ -wot-wg/2020Jul/0052.html)
+STATUS:CONFIRMED
+CREATED:20230201T180546Z
+LAST-MODIFIED:20230529T110716Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RELATED-TO:18c35c2a-47d6-44fe-b198-e438256544f3
+RELATED-TO:19d93ea8-4584-4eef-8fc5-1dc5e39eb45f
+RRULE:FREQ=WEEKLY;UNTIL=20230524T120000Z;INTERVAL=1;BYDAY=WE;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:d61fb100-18b4-405f-97f5-6a831866caa6
+DTSTAMP:20230212T225658Z
+SUMMARY:CANCELLED WoT Main
+DTSTART;TZID=America/New_York:20230215T080000
+DTEND;TZID=America/New_York:20230215T090000
+DESCRIPTION:https://www.w3.org/events/meetings/d61fb100-18b4-405f-97f5-6a83
+ 1866caa6/20230215T080000\n\nThe [Main WoT Web Conference](https://www.w3.o
+ rg/WoT/IG/wiki/Main_WoT_WebConf) is a joint IG/WG call for discussing gene
+ ral WoT IG and WG topics and logistics\, and to provide an opportunity to 
+ summarize and coordinate the activities of the various task forces. For in
+ formation on individual task forces\, please see the [WoT Web Page](https:
+ //www.w3.org/WoT/) or look at the other WoT schedule entries.\n\n[IRC: #wo
+ t](https://irc.w3.org/?channels=wot) / [WebEx](https://lists.w3.org/Archiv
+ es/Member/member-wot-wg/2020Jul/0052.html)
+STATUS:TENTATIVE
+CREATED:20230212T225657Z
+LAST-MODIFIED:20230212T225658Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20230215T080000
+END:VEVENT
+BEGIN:VEVENT
+UID:19d93ea8-4584-4eef-8fc5-1dc5e39eb45f
+DTSTAMP:20230530T122456Z
+SUMMARY:WoT Main
+DTSTART;TZID=America/New_York:20230531T080000
+DTEND;TZID=America/New_York:20230531T090000
+DESCRIPTION:https://www.w3.org/events/meetings/19d93ea8-4584-4eef-8fc5-1dc5
+ e39eb45f\n\nThe [Main WoT Web Conference](https://www.w3.org/WoT/IG/wiki/M
+ ain_WoT_WebConf) is a joint IG/WG call for discussing general WoT IG and W
+ G topics and logistics\, and to provide an opportunity to summarize and co
+ ordinate the activities of the various task forces. For information on ind
+ ividual task forces\, please see the [WoT Web Page](https://www.w3.org/WoT
+ /) or look at the other WoT schedule entries.
+STATUS:CONFIRMED
+CREATED:20230529T110716Z
+LAST-MODIFIED:20230530T122456Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:Zoom
+RELATED-TO:d61fb100-18b4-405f-97f5-6a831866caa6
+RRULE:FREQ=WEEKLY;UNTIL=20230801T120000Z;INTERVAL=1;BYDAY=WE;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:e7862449-888c-426a-b630-f27259fb60a1
+DTSTAMP:20220307T165327Z
+SUMMARY:WoT Scripting API
+DTSTART;TZID=America/New_York:20220307T070000
+DTEND;TZID=America/New_York:20220307T080000
+DESCRIPTION:https://www.w3.org/events/meetings/e7862449-888c-426a-b630-f272
+ 59fb60a1\n\nThe [WoT Scripting API task force](https://www.w3.org/WoT/IG/w
+ iki/WG_WoT_Scripting_API_WebConf) is responsible for specifying an applica
+ tion programming interface (API) representing the WoT Interface that allow
+ s scripts to discover\, invoke interactions with Things\, and expose inter
+ actions for locally defined Things.\n\n[IRC: #wot-scripting](https://irc.w
+ 3.org/?channels=wot-scripting) / [WebEx](https://lists.w3.org/Archives/Mem
+ ber/member-wot-wg/2018Feb/0033.html)
+STATUS:CONFIRMED
+CREATED:20220301T162532Z
+LAST-MODIFIED:20220307T165327Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RRULE:FREQ=WEEKLY;UNTIL=20220307T120000Z;INTERVAL=1;BYDAY=MO;WKST=MO
+RELATED-TO:89618153-e1aa-4e61-9805-01f7227f3b97
+END:VEVENT
+BEGIN:VEVENT
+UID:89618153-e1aa-4e61-9805-01f7227f3b97
+DTSTAMP:20220801T114157Z
+SUMMARY:WoT Scripting API
+DTSTART;TZID=America/New_York:20220314T070000
+DTEND;TZID=America/New_York:20220314T080000
+DESCRIPTION:https://www.w3.org/events/meetings/89618153-e1aa-4e61-9805-01f7
+ 227f3b97\n\nThe [WoT Scripting API task force](https://www.w3.org/WoT/IG/w
+ iki/WG_WoT_Scripting_API_WebConf) is responsible for specifying an applica
+ tion programming interface (API) representing the WoT Interface that allow
+ s scripts to discover\, invoke interactions with Things\, and expose inter
+ actions for locally defined Things.\n\n[IRC: #wot-scripting](https://irc.w
+ 3.org/?channels=wot-scripting) / [WebEx](https://lists.w3.org/Archives/Mem
+ ber/member-wot-wg/2018Feb/0033.html)
+STATUS:CONFIRMED
+CREATED:20220307T165323Z
+LAST-MODIFIED:20220801T114157Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RELATED-TO:e7862449-888c-426a-b630-f27259fb60a1
+RELATED-TO:5d1832fb-2253-4021-81a2-3a8c5839e0b4
+RRULE:FREQ=WEEKLY;UNTIL=20220725T110000Z;INTERVAL=1;BYDAY=MO;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:89618153-e1aa-4e61-9805-01f7227f3b97
+DTSTAMP:20220309T152143Z
+SUMMARY:WoT Scripting API
+DTSTART;TZID=America/New_York:20220314T070000
+DTEND;TZID=America/New_York:20220314T080000
+DESCRIPTION:https://www.w3.org/events/meetings/89618153-e1aa-4e61-9805-01f7
+ 227f3b97/20220314T070000\n\nThe [WoT Scripting API task force](https://www
+ .w3.org/WoT/IG/wiki/WG_WoT_Scripting_API_WebConf) is responsible for speci
+ fying an application programming interface (API) representing the WoT Inte
+ rface that allows scripts to discover\, invoke interactions with Things\, 
+ and expose interactions for locally defined Things.\n\n[IRC: #wot-scriptin
+ g](https://irc.w3.org/?channels=wot-scripting) / [WebEx](https://lists.w3.
+ org/Archives/Member/member-wot-wg/2018Feb/0033.html)
+STATUS:CANCELLED
+CREATED:20220309T152142Z
+LAST-MODIFIED:20220309T152143Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220314T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:89618153-e1aa-4e61-9805-01f7227f3b97
+DTSTAMP:20220413T100722Z
+SUMMARY:WoT Scripting API
+DTSTART;TZID=America/New_York:20220418T070000
+DTEND;TZID=America/New_York:20220418T080000
+DESCRIPTION:https://www.w3.org/events/meetings/89618153-e1aa-4e61-9805-01f7
+ 227f3b97/20220418T070000\n\nThe [WoT Scripting API task force](https://www
+ .w3.org/WoT/IG/wiki/WG_WoT_Scripting_API_WebConf) is responsible for speci
+ fying an application programming interface (API) representing the WoT Inte
+ rface that allows scripts to discover\, invoke interactions with Things\, 
+ and expose interactions for locally defined Things.\n\n[IRC: #wot-scriptin
+ g](https://irc.w3.org/?channels=wot-scripting) / [WebEx](https://lists.w3.
+ org/Archives/Member/member-wot-wg/2018Feb/0033.html)
+STATUS:CANCELLED
+CREATED:20220413T100720Z
+LAST-MODIFIED:20220413T100722Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220418T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:89618153-e1aa-4e61-9805-01f7227f3b97
+DTSTAMP:20220420T100534Z
+SUMMARY:WoT Scripting API
+DTSTART;TZID=America/New_York:20220425T070000
+DTEND;TZID=America/New_York:20220425T080000
+DESCRIPTION:https://www.w3.org/events/meetings/89618153-e1aa-4e61-9805-01f7
+ 227f3b97/20220425T070000\n\nThe [WoT Scripting API task force](https://www
+ .w3.org/WoT/IG/wiki/WG_WoT_Scripting_API_WebConf) is responsible for speci
+ fying an application programming interface (API) representing the WoT Inte
+ rface that allows scripts to discover\, invoke interactions with Things\, 
+ and expose interactions for locally defined Things.\n\n[IRC: #wot-scriptin
+ g](https://irc.w3.org/?channels=wot-scripting) / [WebEx](https://lists.w3.
+ org/Archives/Member/member-wot-wg/2018Feb/0033.html)
+STATUS:CANCELLED
+CREATED:20220420T100533Z
+LAST-MODIFIED:20220420T100534Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220425T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:89618153-e1aa-4e61-9805-01f7227f3b97
+DTSTAMP:20220621T110624Z
+SUMMARY:WoT Scripting API
+DTSTART;TZID=America/New_York:20220627T070000
+DTEND;TZID=America/New_York:20220627T080000
+DESCRIPTION:https://www.w3.org/events/meetings/89618153-e1aa-4e61-9805-01f7
+ 227f3b97/20220627T070000\n\nThe [WoT Scripting API task force](https://www
+ .w3.org/WoT/IG/wiki/WG_WoT_Scripting_API_WebConf) is responsible for speci
+ fying an application programming interface (API) representing the WoT Inte
+ rface that allows scripts to discover\, invoke interactions with Things\, 
+ and expose interactions for locally defined Things.\n\n[IRC: #wot-scriptin
+ g](https://irc.w3.org/?channels=wot-scripting) / [WebEx](https://lists.w3.
+ org/Archives/Member/member-wot-wg/2018Feb/0033.html)
+STATUS:CANCELLED
+CREATED:20220621T110623Z
+LAST-MODIFIED:20220621T110624Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220627T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:89618153-e1aa-4e61-9805-01f7227f3b97
+DTSTAMP:20220720T143929Z
+SUMMARY:WoT Scripting API
+DTSTART;TZID=America/New_York:20220725T070000
+DTEND;TZID=America/New_York:20220725T080000
+DESCRIPTION:https://www.w3.org/events/meetings/89618153-e1aa-4e61-9805-01f7
+ 227f3b97/20220725T070000\n\nThe [WoT Scripting API task force](https://www
+ .w3.org/WoT/IG/wiki/WG_WoT_Scripting_API_WebConf) is responsible for speci
+ fying an application programming interface (API) representing the WoT Inte
+ rface that allows scripts to discover\, invoke interactions with Things\, 
+ and expose interactions for locally defined Things.\n\n[IRC: #wot-scriptin
+ g](https://irc.w3.org/?channels=wot-scripting) / [WebEx](https://lists.w3.
+ org/Archives/Member/member-wot-wg/2018Feb/0033.html)
+STATUS:CANCELLED
+CREATED:20220720T143928Z
+LAST-MODIFIED:20220720T143929Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220725T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:5d1832fb-2253-4021-81a2-3a8c5839e0b4
+DTSTAMP:20230201T170641Z
+SUMMARY:WoT Scripting API
+DTSTART;TZID=America/New_York:20220801T070000
+DTEND;TZID=America/New_York:20220801T080000
+DESCRIPTION:https://www.w3.org/events/meetings/5d1832fb-2253-4021-81a2-3a8c
+ 5839e0b4\n\nThe [WoT Scripting API task force](https://www.w3.org/WoT/IG/w
+ iki/WG_WoT_Scripting_API_WebConf) is responsible for specifying an applica
+ tion programming interface (API) representing the WoT Interface that allow
+ s scripts to discover\, invoke interactions with Things\, and expose inter
+ actions for locally defined Things.\n\n[IRC: #wot-script](https://irc.w3.o
+ rg/?channels=wot-script) / [WebEx](https://lists.w3.org/Archives/Member/me
+ mber-wot-wg/2018Feb/0033.html)
+STATUS:CONFIRMED
+CREATED:20220801T114155Z
+LAST-MODIFIED:20230201T170641Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RELATED-TO:89618153-e1aa-4e61-9805-01f7227f3b97
+RELATED-TO:5da60ebc-4acb-4a54-8954-60921a8ce31f
+RRULE:FREQ=WEEKLY;UNTIL=20230123T120000Z;INTERVAL=1;BYDAY=MO;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:5d1832fb-2253-4021-81a2-3a8c5839e0b4
+DTSTAMP:20220810T100312Z
+SUMMARY:WoT Scripting API
+DTSTART;TZID=America/New_York:20220815T070000
+DTEND;TZID=America/New_York:20220815T080000
+DESCRIPTION:https://www.w3.org/events/meetings/5d1832fb-2253-4021-81a2-3a8c
+ 5839e0b4/20220815T070000\n\nThe [WoT Scripting API task force](https://www
+ .w3.org/WoT/IG/wiki/WG_WoT_Scripting_API_WebConf) is responsible for speci
+ fying an application programming interface (API) representing the WoT Inte
+ rface that allows scripts to discover\, invoke interactions with Things\, 
+ and expose interactions for locally defined Things.\n\n[IRC: #wot-script](
+ https://irc.w3.org/?channels=wot-script) / [WebEx](https://lists.w3.org/Ar
+ chives/Member/member-wot-wg/2018Feb/0033.html)
+STATUS:CANCELLED
+CREATED:20220810T100310Z
+LAST-MODIFIED:20220810T100312Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220815T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:5d1832fb-2253-4021-81a2-3a8c5839e0b4
+DTSTAMP:20220810T100547Z
+SUMMARY:WoT Scripting API
+DTSTART;TZID=America/New_York:20220829T070000
+DTEND;TZID=America/New_York:20220829T080000
+DESCRIPTION:https://www.w3.org/events/meetings/5d1832fb-2253-4021-81a2-3a8c
+ 5839e0b4/20220829T070000\n\nThe [WoT Scripting API task force](https://www
+ .w3.org/WoT/IG/wiki/WG_WoT_Scripting_API_WebConf) is responsible for speci
+ fying an application programming interface (API) representing the WoT Inte
+ rface that allows scripts to discover\, invoke interactions with Things\, 
+ and expose interactions for locally defined Things.\n\n[IRC: #wot-script](
+ https://irc.w3.org/?channels=wot-script) / [WebEx](https://lists.w3.org/Ar
+ chives/Member/member-wot-wg/2018Feb/0033.html)
+STATUS:CANCELLED
+CREATED:20220810T100545Z
+LAST-MODIFIED:20220810T100547Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220829T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:5d1832fb-2253-4021-81a2-3a8c5839e0b4
+DTSTAMP:20220831T161718Z
+SUMMARY:WoT Scripting API
+DTSTART;TZID=America/New_York:20220912T070000
+DTEND;TZID=America/New_York:20220912T080000
+DESCRIPTION:https://www.w3.org/events/meetings/5d1832fb-2253-4021-81a2-3a8c
+ 5839e0b4/20220912T070000\n\nThe [WoT Scripting API task force](https://www
+ .w3.org/WoT/IG/wiki/WG_WoT_Scripting_API_WebConf) is responsible for speci
+ fying an application programming interface (API) representing the WoT Inte
+ rface that allows scripts to discover\, invoke interactions with Things\, 
+ and expose interactions for locally defined Things.\n\n[IRC: #wot-script](
+ https://irc.w3.org/?channels=wot-script) / [WebEx](https://lists.w3.org/Ar
+ chives/Member/member-wot-wg/2018Feb/0033.html)
+STATUS:CANCELLED
+CREATED:20220831T161716Z
+LAST-MODIFIED:20220831T161718Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220912T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:5d1832fb-2253-4021-81a2-3a8c5839e0b4
+DTSTAMP:20220916T131703Z
+SUMMARY:WoT Scripting API
+DTSTART;TZID=America/New_York:20220919T070000
+DTEND;TZID=America/New_York:20220919T080000
+DESCRIPTION:https://www.w3.org/events/meetings/5d1832fb-2253-4021-81a2-3a8c
+ 5839e0b4/20220919T070000\n\nThe [WoT Scripting API task force](https://www
+ .w3.org/WoT/IG/wiki/WG_WoT_Scripting_API_WebConf) is responsible for speci
+ fying an application programming interface (API) representing the WoT Inte
+ rface that allows scripts to discover\, invoke interactions with Things\, 
+ and expose interactions for locally defined Things.\n\n[IRC: #wot-script](
+ https://irc.w3.org/?channels=wot-script) / [WebEx](https://lists.w3.org/Ar
+ chives/Member/member-wot-wg/2018Feb/0033.html)
+STATUS:CANCELLED
+CREATED:20220916T131701Z
+LAST-MODIFIED:20220916T131703Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220919T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:5d1832fb-2253-4021-81a2-3a8c5839e0b4
+DTSTAMP:20221003T105841Z
+SUMMARY:WoT Scripting API
+DTSTART;TZID=America/New_York:20221003T070000
+DTEND;TZID=America/New_York:20221003T080000
+DESCRIPTION:https://www.w3.org/events/meetings/5d1832fb-2253-4021-81a2-3a8c
+ 5839e0b4/20221003T070000\n\nThe [WoT Scripting API task force](https://www
+ .w3.org/WoT/IG/wiki/WG_WoT_Scripting_API_WebConf) is responsible for speci
+ fying an application programming interface (API) representing the WoT Inte
+ rface that allows scripts to discover\, invoke interactions with Things\, 
+ and expose interactions for locally defined Things.\n\n[IRC: #wot-script](
+ https://irc.w3.org/?channels=wot-script) / [WebEx](https://lists.w3.org/Ar
+ chives/Member/member-wot-wg/2018Feb/0033.html)
+STATUS:CANCELLED
+CREATED:20221003T105840Z
+LAST-MODIFIED:20221003T105841Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20221003T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:5d1832fb-2253-4021-81a2-3a8c5839e0b4
+DTSTAMP:20221207T165630Z
+SUMMARY:WoT Scripting API
+DTSTART;TZID=America/New_York:20221212T070000
+DTEND;TZID=America/New_York:20221212T080000
+DESCRIPTION:https://www.w3.org/events/meetings/5d1832fb-2253-4021-81a2-3a8c
+ 5839e0b4/20221212T070000\n\nThe [WoT Scripting API task force](https://www
+ .w3.org/WoT/IG/wiki/WG_WoT_Scripting_API_WebConf) is responsible for speci
+ fying an application programming interface (API) representing the WoT Inte
+ rface that allows scripts to discover\, invoke interactions with Things\, 
+ and expose interactions for locally defined Things.\n\n[IRC: #wot-script](
+ https://irc.w3.org/?channels=wot-script) / [WebEx](https://lists.w3.org/Ar
+ chives/Member/member-wot-wg/2018Feb/0033.html)
+STATUS:TENTATIVE
+CREATED:20221207T165628Z
+LAST-MODIFIED:20221207T165630Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20221212T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:5d1832fb-2253-4021-81a2-3a8c5839e0b4
+DTSTAMP:20230111T112035Z
+SUMMARY:WoT Scripting API
+DTSTART;TZID=America/New_York:20230116T070000
+DTEND;TZID=America/New_York:20230116T080000
+DESCRIPTION:https://www.w3.org/events/meetings/5d1832fb-2253-4021-81a2-3a8c
+ 5839e0b4/20230116T070000\n\nThe [WoT Scripting API task force](https://www
+ .w3.org/WoT/IG/wiki/WG_WoT_Scripting_API_WebConf) is responsible for speci
+ fying an application programming interface (API) representing the WoT Inte
+ rface that allows scripts to discover\, invoke interactions with Things\, 
+ and expose interactions for locally defined Things.\n\n[IRC: #wot-script](
+ https://irc.w3.org/?channels=wot-script) / [WebEx](https://lists.w3.org/Ar
+ chives/Member/member-wot-wg/2018Feb/0033.html)
+STATUS:CANCELLED
+CREATED:20230111T112034Z
+LAST-MODIFIED:20230111T112035Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20230116T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:5da60ebc-4acb-4a54-8954-60921a8ce31f
+DTSTAMP:20230529T101459Z
+SUMMARY:WoT Scripting API
+DTSTART;TZID=America/New_York:20230130T070000
+DTEND;TZID=America/New_York:20230130T080000
+DESCRIPTION:https://www.w3.org/events/meetings/5da60ebc-4acb-4a54-8954-6092
+ 1a8ce31f\n\nThe [WoT Scripting API task force](https://www.w3.org/WoT/IG/w
+ iki/WG_WoT_Scripting_API_WebConf) is responsible for specifying an applica
+ tion programming interface (API) representing the WoT Interface that allow
+ s scripts to discover\, invoke interactions with Things\, and expose inter
+ actions for locally defined Things.\n\n[IRC: #wot-script](https://irc.w3.o
+ rg/?channels=wot-script) / [WebEx](https://lists.w3.org/Archives/Member/me
+ mber-wot-wg/2018Feb/0033.html)
+STATUS:CONFIRMED
+CREATED:20230201T170639Z
+LAST-MODIFIED:20230529T101459Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RELATED-TO:5d1832fb-2253-4021-81a2-3a8c5839e0b4
+RELATED-TO:600dddbd-4c6f-44c2-8b73-677888e471c4
+RRULE:FREQ=WEEKLY;UNTIL=20230522T110000Z;INTERVAL=1;BYDAY=MO;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:5da60ebc-4acb-4a54-8954-60921a8ce31f
+DTSTAMP:20230212T225535Z
+SUMMARY:CANCELLED WoT Scripting API
+DTSTART;TZID=America/New_York:20230213T070000
+DTEND;TZID=America/New_York:20230213T080000
+DESCRIPTION:https://www.w3.org/events/meetings/5da60ebc-4acb-4a54-8954-6092
+ 1a8ce31f/20230213T070000\n\nThe [WoT Scripting API task force](https://www
+ .w3.org/WoT/IG/wiki/WG_WoT_Scripting_API_WebConf) is responsible for speci
+ fying an application programming interface (API) representing the WoT Inte
+ rface that allows scripts to discover\, invoke interactions with Things\, 
+ and expose interactions for locally defined Things.\n\n[IRC: #wot-script](
+ https://irc.w3.org/?channels=wot-script) / [WebEx](https://lists.w3.org/Ar
+ chives/Member/member-wot-wg/2018Feb/0033.html)
+STATUS:TENTATIVE
+CREATED:20230212T225534Z
+LAST-MODIFIED:20230212T225535Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20230213T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:600dddbd-4c6f-44c2-8b73-677888e471c4
+DTSTAMP:20230529T103521Z
+SUMMARY:WoT Scripting API
+DTSTART;TZID=America/New_York:20230529T070000
+DTEND;TZID=America/New_York:20230529T080000
+DESCRIPTION:https://www.w3.org/events/meetings/600dddbd-4c6f-44c2-8b73-6778
+ 88e471c4\n\nThe [WoT Scripting API task force](https://www.w3.org/WoT/IG/w
+ iki/WG_WoT_Scripting_API_WebConf) is responsible for specifying an applica
+ tion programming interface (API) representing the WoT Interface that allow
+ s scripts to discover\, invoke interactions with Things\, and expose inter
+ actions for locally defined Things.
+STATUS:CONFIRMED
+CREATED:20230529T101459Z
+LAST-MODIFIED:20230529T103521Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:Zoom
+RELATED-TO:5da60ebc-4acb-4a54-8954-60921a8ce31f
+RRULE:FREQ=WEEKLY;UNTIL=20230801T110000Z;INTERVAL=1;BYDAY=MO;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:874094bf-a965-4200-bdf9-7a2806a01685
+DTSTAMP:20230201T170553Z
+SUMMARY:WoT Security
+DTSTART;TZID=America/New_York:20220307T080000
+DTEND;TZID=America/New_York:20220307T090000
+DESCRIPTION:https://www.w3.org/events/meetings/874094bf-a965-4200-bdf9-7a28
+ 06a01685\n\nThe [WoT Security task force](https://www.w3.org/WoT/IG/wiki/I
+ G_Security_WebConf) is responsible for identifying and analyzing the secur
+ ity and privacy considerations of the WoT and providing recommendations to
+  support appropriate security technologies and to mitigate security and pr
+ ivacy risks.\n\n[IRC: #wot-sec](https://irc.w3.org/?channels=wot-sec) / [W
+ ebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2019Nov/0006.html
+ )
+STATUS:CONFIRMED
+CREATED:20220301T163519Z
+LAST-MODIFIED:20230201T170553Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RRULE:FREQ=WEEKLY;UNTIL=20230123T130000Z;INTERVAL=1;BYDAY=MO;WKST=MO
+RELATED-TO:7bcfa496-e813-4eb8-9581-b01a629b3402
+END:VEVENT
+BEGIN:VEVENT
+UID:874094bf-a965-4200-bdf9-7a2806a01685
+DTSTAMP:20220307T135753Z
+SUMMARY:WoT Security
+DTSTART;TZID=America/New_York:20220314T080000
+DTEND;TZID=America/New_York:20220314T090000
+DESCRIPTION:https://www.w3.org/events/meetings/874094bf-a965-4200-bdf9-7a28
+ 06a01685/20220314T080000\n\nThe [WoT Security task force](https://www.w3.o
+ rg/WoT/IG/wiki/IG_Security_WebConf) is responsible for identifying and ana
+ lyzing the security and privacy considerations of the WoT and providing re
+ commendations to support appropriate security technologies and to mitigate
+  security and privacy risks.\n\n[IRC: #wot-sec](https://irc.w3.org/?channe
+ ls=wot-sec) / [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2
+ 019Nov/0006.html)
+STATUS:CANCELLED
+CREATED:20220307T135751Z
+LAST-MODIFIED:20220307T135753Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220314T080000
+END:VEVENT
+BEGIN:VEVENT
+UID:874094bf-a965-4200-bdf9-7a2806a01685
+DTSTAMP:20220606T115142Z
+SUMMARY:WoT Security
+DTSTART;TZID=America/New_York:20220606T080000
+DTEND;TZID=America/New_York:20220606T090000
+DESCRIPTION:https://www.w3.org/events/meetings/874094bf-a965-4200-bdf9-7a28
+ 06a01685/20220606T080000\n\nThe [WoT Security task force](https://www.w3.o
+ rg/WoT/IG/wiki/IG_Security_WebConf) is responsible for identifying and ana
+ lyzing the security and privacy considerations of the WoT and providing re
+ commendations to support appropriate security technologies and to mitigate
+  security and privacy risks.\n\n[IRC: #wot-sec](https://irc.w3.org/?channe
+ ls=wot-sec) / [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2
+ 019Nov/0006.html)
+STATUS:CANCELLED
+CREATED:20220606T115141Z
+LAST-MODIFIED:20220606T115142Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220606T080000
+END:VEVENT
+BEGIN:VEVENT
+UID:874094bf-a965-4200-bdf9-7a2806a01685
+DTSTAMP:20220720T143953Z
+SUMMARY:WoT Security
+DTSTART;TZID=America/New_York:20220725T080000
+DTEND;TZID=America/New_York:20220725T090000
+DESCRIPTION:https://www.w3.org/events/meetings/874094bf-a965-4200-bdf9-7a28
+ 06a01685/20220725T080000\n\nThe [WoT Security task force](https://www.w3.o
+ rg/WoT/IG/wiki/IG_Security_WebConf) is responsible for identifying and ana
+ lyzing the security and privacy considerations of the WoT and providing re
+ commendations to support appropriate security technologies and to mitigate
+  security and privacy risks.\n\n[IRC: #wot-sec](https://irc.w3.org/?channe
+ ls=wot-sec) / [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2
+ 019Nov/0006.html)
+STATUS:CANCELLED
+CREATED:20220720T143951Z
+LAST-MODIFIED:20220720T143953Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220725T080000
+END:VEVENT
+BEGIN:VEVENT
+UID:874094bf-a965-4200-bdf9-7a2806a01685
+DTSTAMP:20220810T100347Z
+SUMMARY:WoT Security
+DTSTART;TZID=America/New_York:20220815T080000
+DTEND;TZID=America/New_York:20220815T090000
+DESCRIPTION:https://www.w3.org/events/meetings/874094bf-a965-4200-bdf9-7a28
+ 06a01685/20220815T080000\n\nThe [WoT Security task force](https://www.w3.o
+ rg/WoT/IG/wiki/IG_Security_WebConf) is responsible for identifying and ana
+ lyzing the security and privacy considerations of the WoT and providing re
+ commendations to support appropriate security technologies and to mitigate
+  security and privacy risks.\n\n[IRC: #wot-sec](https://irc.w3.org/?channe
+ ls=wot-sec) / [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2
+ 019Nov/0006.html)
+STATUS:CANCELLED
+CREATED:20220810T100346Z
+LAST-MODIFIED:20220810T100347Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220815T080000
+END:VEVENT
+BEGIN:VEVENT
+UID:874094bf-a965-4200-bdf9-7a2806a01685
+DTSTAMP:20220823T131619Z
+SUMMARY:WoT Security
+DTSTART;TZID=America/New_York:20220829T080000
+DTEND;TZID=America/New_York:20220829T090000
+DESCRIPTION:https://www.w3.org/events/meetings/874094bf-a965-4200-bdf9-7a28
+ 06a01685/20220829T080000\n\nThe [WoT Security task force](https://www.w3.o
+ rg/WoT/IG/wiki/IG_Security_WebConf) is responsible for identifying and ana
+ lyzing the security and privacy considerations of the WoT and providing re
+ commendations to support appropriate security technologies and to mitigate
+  security and privacy risks.\n\n[IRC: #wot-sec](https://irc.w3.org/?channe
+ ls=wot-sec) / [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2
+ 019Nov/0006.html)
+STATUS:CANCELLED
+CREATED:20220823T131618Z
+LAST-MODIFIED:20220823T131619Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220829T080000
+END:VEVENT
+BEGIN:VEVENT
+UID:874094bf-a965-4200-bdf9-7a2806a01685
+DTSTAMP:20220831T161122Z
+SUMMARY:WoT Security
+DTSTART;TZID=America/New_York:20220905T080000
+DTEND;TZID=America/New_York:20220905T090000
+DESCRIPTION:https://www.w3.org/events/meetings/874094bf-a965-4200-bdf9-7a28
+ 06a01685/20220905T080000\n\nThe [WoT Security task force](https://www.w3.o
+ rg/WoT/IG/wiki/IG_Security_WebConf) is responsible for identifying and ana
+ lyzing the security and privacy considerations of the WoT and providing re
+ commendations to support appropriate security technologies and to mitigate
+  security and privacy risks.\n\n[IRC: #wot-sec](https://irc.w3.org/?channe
+ ls=wot-sec) / [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2
+ 019Nov/0006.html)
+STATUS:CANCELLED
+CREATED:20220831T161121Z
+LAST-MODIFIED:20220831T161122Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220905T080000
+END:VEVENT
+BEGIN:VEVENT
+UID:874094bf-a965-4200-bdf9-7a2806a01685
+DTSTAMP:20220831T161745Z
+SUMMARY:WoT Security
+DTSTART;TZID=America/New_York:20220912T080000
+DTEND;TZID=America/New_York:20220912T090000
+DESCRIPTION:https://www.w3.org/events/meetings/874094bf-a965-4200-bdf9-7a28
+ 06a01685/20220912T080000\n\nThe [WoT Security task force](https://www.w3.o
+ rg/WoT/IG/wiki/IG_Security_WebConf) is responsible for identifying and ana
+ lyzing the security and privacy considerations of the WoT and providing re
+ commendations to support appropriate security technologies and to mitigate
+  security and privacy risks.\n\n[IRC: #wot-sec](https://irc.w3.org/?channe
+ ls=wot-sec) / [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2
+ 019Nov/0006.html)
+STATUS:CANCELLED
+CREATED:20220831T161744Z
+LAST-MODIFIED:20220831T161745Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220912T080000
+END:VEVENT
+BEGIN:VEVENT
+UID:874094bf-a965-4200-bdf9-7a2806a01685
+DTSTAMP:20220916T131722Z
+SUMMARY:WoT Security
+DTSTART;TZID=America/New_York:20220919T080000
+DTEND;TZID=America/New_York:20220919T090000
+DESCRIPTION:https://www.w3.org/events/meetings/874094bf-a965-4200-bdf9-7a28
+ 06a01685/20220919T080000\n\nThe [WoT Security task force](https://www.w3.o
+ rg/WoT/IG/wiki/IG_Security_WebConf) is responsible for identifying and ana
+ lyzing the security and privacy considerations of the WoT and providing re
+ commendations to support appropriate security technologies and to mitigate
+  security and privacy risks.\n\n[IRC: #wot-sec](https://irc.w3.org/?channe
+ ls=wot-sec) / [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2
+ 019Nov/0006.html)
+STATUS:CANCELLED
+CREATED:20220916T131721Z
+LAST-MODIFIED:20220916T131722Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220919T080000
+END:VEVENT
+BEGIN:VEVENT
+UID:874094bf-a965-4200-bdf9-7a2806a01685
+DTSTAMP:20221003T105904Z
+SUMMARY:WoT Security
+DTSTART;TZID=America/New_York:20221003T080000
+DTEND;TZID=America/New_York:20221003T090000
+DESCRIPTION:https://www.w3.org/events/meetings/874094bf-a965-4200-bdf9-7a28
+ 06a01685/20221003T080000\n\nThe [WoT Security task force](https://www.w3.o
+ rg/WoT/IG/wiki/IG_Security_WebConf) is responsible for identifying and ana
+ lyzing the security and privacy considerations of the WoT and providing re
+ commendations to support appropriate security technologies and to mitigate
+  security and privacy risks.\n\n[IRC: #wot-sec](https://irc.w3.org/?channe
+ ls=wot-sec) / [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2
+ 019Nov/0006.html)
+STATUS:CANCELLED
+CREATED:20221003T105903Z
+LAST-MODIFIED:20221003T105904Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20221003T080000
+END:VEVENT
+BEGIN:VEVENT
+UID:874094bf-a965-4200-bdf9-7a2806a01685
+DTSTAMP:20221207T165653Z
+SUMMARY:WoT Security
+DTSTART;TZID=America/New_York:20221212T080000
+DTEND;TZID=America/New_York:20221212T090000
+DESCRIPTION:https://www.w3.org/events/meetings/874094bf-a965-4200-bdf9-7a28
+ 06a01685/20221212T080000\n\nThe [WoT Security task force](https://www.w3.o
+ rg/WoT/IG/wiki/IG_Security_WebConf) is responsible for identifying and ana
+ lyzing the security and privacy considerations of the WoT and providing re
+ commendations to support appropriate security technologies and to mitigate
+  security and privacy risks.\n\n[IRC: #wot-sec](https://irc.w3.org/?channe
+ ls=wot-sec) / [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2
+ 019Nov/0006.html)
+STATUS:CANCELLED
+CREATED:20221207T165651Z
+LAST-MODIFIED:20221207T165653Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20221212T080000
+END:VEVENT
+BEGIN:VEVENT
+UID:874094bf-a965-4200-bdf9-7a2806a01685
+DTSTAMP:20230111T112102Z
+SUMMARY:WoT Security
+DTSTART;TZID=America/New_York:20230116T080000
+DTEND;TZID=America/New_York:20230116T090000
+DESCRIPTION:https://www.w3.org/events/meetings/874094bf-a965-4200-bdf9-7a28
+ 06a01685/20230116T080000\n\nThe [WoT Security task force](https://www.w3.o
+ rg/WoT/IG/wiki/IG_Security_WebConf) is responsible for identifying and ana
+ lyzing the security and privacy considerations of the WoT and providing re
+ commendations to support appropriate security technologies and to mitigate
+  security and privacy risks.\n\n[IRC: #wot-sec](https://irc.w3.org/?channe
+ ls=wot-sec) / [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2
+ 019Nov/0006.html)
+STATUS:CANCELLED
+CREATED:20230111T112101Z
+LAST-MODIFIED:20230111T112102Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20230116T080000
+END:VEVENT
+BEGIN:VEVENT
+UID:7bcfa496-e813-4eb8-9581-b01a629b3402
+DTSTAMP:20230529T103453Z
+SUMMARY:WoT Security
+DTSTART;TZID=America/New_York:20230130T080000
+DTEND;TZID=America/New_York:20230130T090000
+DESCRIPTION:https://www.w3.org/events/meetings/7bcfa496-e813-4eb8-9581-b01a
+ 629b3402\n\nThe [WoT Security task force](https://www.w3.org/WoT/IG/wiki/I
+ G_Security_WebConf) is responsible for identifying and analyzing the secur
+ ity and privacy considerations of the WoT and providing recommendations to
+  support appropriate security technologies and to mitigate security and pr
+ ivacy risks.\n\n[IRC: #wot-sec](https://irc.w3.org/?channels=wot-sec) / [W
+ ebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2019Nov/0006.html
+ )
+STATUS:CONFIRMED
+CREATED:20230201T170551Z
+LAST-MODIFIED:20230529T103453Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RELATED-TO:874094bf-a965-4200-bdf9-7a2806a01685
+RELATED-TO:58c75826-e874-4ed0-987e-fe942c8dfef9
+RRULE:FREQ=WEEKLY;UNTIL=20230522T120000Z;INTERVAL=1;BYDAY=MO;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:58c75826-e874-4ed0-987e-fe942c8dfef9
+DTSTAMP:20230529T103453Z
+SUMMARY:WoT Security
+DTSTART;TZID=America/New_York:20230529T080000
+DTEND;TZID=America/New_York:20230529T090000
+DESCRIPTION:https://www.w3.org/events/meetings/58c75826-e874-4ed0-987e-fe94
+ 2c8dfef9\n\nThe [WoT Security task force](https://www.w3.org/WoT/IG/wiki/I
+ G_Security_WebConf) is responsible for identifying and analyzing the secur
+ ity and privacy considerations of the WoT and providing recommendations to
+  support appropriate security technologies and to mitigate security and pr
+ ivacy risks.
+STATUS:CONFIRMED
+CREATED:20230529T103453Z
+LAST-MODIFIED:20230529T103453Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:Zoom
+RELATED-TO:7bcfa496-e813-4eb8-9581-b01a629b3402
+RRULE:FREQ=WEEKLY;UNTIL=20230801T120000Z;INTERVAL=1;BYDAY=MO;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:28e436af-44de-4a81-b8e9-864ce05ed483
+DTSTAMP:20220606T140053Z
+SUMMARY:WoT Discovery
+DTSTART;TZID=America/New_York:20220307T100000
+DTEND;TZID=America/New_York:20220307T110000
+DESCRIPTION:https://www.w3.org/events/meetings/28e436af-44de-4a81-b8e9-864c
+ e05ed483\n\nThe [WoT Discovery task force](https://www.w3.org/WoT/IG/wiki/
+ WG_WoT_Discovery_WebConf) is responsible for defining a distribution mecha
+ nism for WoT Thing Descriptions that can be used to facilitate access to W
+ oT Things and services while supporting security and privacy.\n\n[IRC: #wo
+ t-discovery](https://irc.w3.org/?channels=wot-discovery) / [WebEx](https:/
+ /lists.w3.org/Archives/Member/member-wot-wg/2020Feb/0009.html)
+STATUS:CONFIRMED
+CREATED:20220301T201755Z
+LAST-MODIFIED:20220606T140053Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RRULE:FREQ=WEEKLY;UNTIL=20220530T140000Z;INTERVAL=1;BYDAY=MO;WKST=MO
+RELATED-TO:ebd5f2e7-7152-4161-83be-e4489b962ccc
+END:VEVENT
+BEGIN:VEVENT
+UID:28e436af-44de-4a81-b8e9-864ce05ed483
+DTSTAMP:20220413T101548Z
+SUMMARY:WoT Discovery
+DTSTART;TZID=America/New_York:20220425T100000
+DTEND;TZID=America/New_York:20220425T110000
+DESCRIPTION:https://www.w3.org/events/meetings/28e436af-44de-4a81-b8e9-864c
+ e05ed483/20220425T100000\n\nThe [WoT Discovery task force](https://www.w3.
+ org/WoT/IG/wiki/WG_WoT_Discovery_WebConf) is responsible for defining a di
+ stribution mechanism for WoT Thing Descriptions that can be used to facili
+ tate access to WoT Things and services while supporting security and priva
+ cy.\n\n[IRC: #wot-discovery](https://irc.w3.org/?channels=wot-discovery) /
+  [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2020Feb/0009.h
+ tml)
+STATUS:CANCELLED
+CREATED:20220413T101547Z
+LAST-MODIFIED:20220413T101548Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220425T100000
+END:VEVENT
+BEGIN:VEVENT
+UID:ebd5f2e7-7152-4161-83be-e4489b962ccc
+DTSTAMP:20230201T170909Z
+SUMMARY:WoT Discovery
+DTSTART;TZID=America/New_York:20220606T100000
+DTEND;TZID=America/New_York:20220606T110000
+DESCRIPTION:https://www.w3.org/events/meetings/ebd5f2e7-7152-4161-83be-e448
+ 9b962ccc\n\nThe [WoT Discovery task force](https://www.w3.org/WoT/IG/wiki/
+ WG_WoT_Discovery_WebConf) is responsible for defining a distribution mecha
+ nism for WoT Thing Descriptions that can be used to facilitate access to W
+ oT Things and services while supporting security and privacy.\n\n[IRC: #wo
+ t-discovery](https://irc.w3.org/?channels=wot-discovery) / [WebEx](https:/
+ /lists.w3.org/Archives/Member/member-wot-wg/2020Feb/0009.html)
+STATUS:CONFIRMED
+CREATED:20220606T140051Z
+LAST-MODIFIED:20230201T170909Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RELATED-TO:28e436af-44de-4a81-b8e9-864ce05ed483
+RELATED-TO:42c02811-3117-4a03-aec4-9a5789dbc78c
+RRULE:FREQ=WEEKLY;UNTIL=20230116T150000Z;INTERVAL=1;BYDAY=MO;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:ebd5f2e7-7152-4161-83be-e4489b962ccc
+DTSTAMP:20220720T144022Z
+SUMMARY:WoT Discovery
+DTSTART;TZID=America/New_York:20220725T100000
+DTEND;TZID=America/New_York:20220725T110000
+DESCRIPTION:https://www.w3.org/events/meetings/ebd5f2e7-7152-4161-83be-e448
+ 9b962ccc/20220725T100000\n\nThe [WoT Discovery task force](https://www.w3.
+ org/WoT/IG/wiki/WG_WoT_Discovery_WebConf) is responsible for defining a di
+ stribution mechanism for WoT Thing Descriptions that can be used to facili
+ tate access to WoT Things and services while supporting security and priva
+ cy.\n\n[IRC: #wot-discovery](https://irc.w3.org/?channels=wot-discovery) /
+  [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2020Feb/0009.h
+ tml)
+STATUS:CANCELLED
+CREATED:20220720T144021Z
+LAST-MODIFIED:20220720T144022Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220725T100000
+END:VEVENT
+BEGIN:VEVENT
+UID:ebd5f2e7-7152-4161-83be-e4489b962ccc
+DTSTAMP:20220810T100436Z
+SUMMARY:WoT Discovery
+DTSTART;TZID=America/New_York:20220815T100000
+DTEND;TZID=America/New_York:20220815T110000
+DESCRIPTION:https://www.w3.org/events/meetings/ebd5f2e7-7152-4161-83be-e448
+ 9b962ccc/20220815T100000\n\nThe [WoT Discovery task force](https://www.w3.
+ org/WoT/IG/wiki/WG_WoT_Discovery_WebConf) is responsible for defining a di
+ stribution mechanism for WoT Thing Descriptions that can be used to facili
+ tate access to WoT Things and services while supporting security and priva
+ cy.\n\n[IRC: #wot-discovery](https://irc.w3.org/?channels=wot-discovery) /
+  [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2020Feb/0009.h
+ tml)
+STATUS:CANCELLED
+CREATED:20220810T100435Z
+LAST-MODIFIED:20220810T100436Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220815T100000
+END:VEVENT
+BEGIN:VEVENT
+UID:ebd5f2e7-7152-4161-83be-e4489b962ccc
+DTSTAMP:20220810T100714Z
+SUMMARY:WoT Discovery
+DTSTART;TZID=America/New_York:20220829T100000
+DTEND;TZID=America/New_York:20220829T110000
+DESCRIPTION:https://www.w3.org/events/meetings/ebd5f2e7-7152-4161-83be-e448
+ 9b962ccc/20220829T100000\n\nThe [WoT Discovery task force](https://www.w3.
+ org/WoT/IG/wiki/WG_WoT_Discovery_WebConf) is responsible for defining a di
+ stribution mechanism for WoT Thing Descriptions that can be used to facili
+ tate access to WoT Things and services while supporting security and priva
+ cy.\n\n[IRC: #wot-discovery](https://irc.w3.org/?channels=wot-discovery) /
+  [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2020Feb/0009.h
+ tml)
+STATUS:CANCELLED
+CREATED:20220810T100713Z
+LAST-MODIFIED:20220810T100714Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220829T100000
+END:VEVENT
+BEGIN:VEVENT
+UID:ebd5f2e7-7152-4161-83be-e4489b962ccc
+DTSTAMP:20220831T161217Z
+SUMMARY:WoT Discovery
+DTSTART;TZID=America/New_York:20220905T100000
+DTEND;TZID=America/New_York:20220905T120000
+DESCRIPTION:https://www.w3.org/events/meetings/ebd5f2e7-7152-4161-83be-e448
+ 9b962ccc/20220905T100000\n\nNote: this will be a special 2h meeting\n\nThe
+  [WoT Discovery task force](https://www.w3.org/WoT/IG/wiki/WG_WoT_Discover
+ y_WebConf) is responsible for defining a distribution mechanism for WoT Th
+ ing Descriptions that can be used to facilitate access to WoT Things and s
+ ervices while supporting security and privacy.\n\n[IRC: #wot-discovery](ht
+ tps://irc.w3.org/?channels=wot-discovery) / [WebEx](https://lists.w3.org/A
+ rchives/Member/member-wot-wg/2020Feb/0009.html)
+STATUS:CONFIRMED
+CREATED:20220831T161216Z
+LAST-MODIFIED:20220831T161217Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220905T100000
+END:VEVENT
+BEGIN:VEVENT
+UID:ebd5f2e7-7152-4161-83be-e4489b962ccc
+DTSTAMP:20220831T161818Z
+SUMMARY:WoT Discovery
+DTSTART;TZID=America/New_York:20220912T100000
+DTEND;TZID=America/New_York:20220912T110000
+DESCRIPTION:https://www.w3.org/events/meetings/ebd5f2e7-7152-4161-83be-e448
+ 9b962ccc/20220912T100000\n\nThe [WoT Discovery task force](https://www.w3.
+ org/WoT/IG/wiki/WG_WoT_Discovery_WebConf) is responsible for defining a di
+ stribution mechanism for WoT Thing Descriptions that can be used to facili
+ tate access to WoT Things and services while supporting security and priva
+ cy.\n\n[IRC: #wot-discovery](https://irc.w3.org/?channels=wot-discovery) /
+  [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2020Feb/0009.h
+ tml)
+STATUS:CANCELLED
+CREATED:20220831T161816Z
+LAST-MODIFIED:20220831T161818Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220912T100000
+END:VEVENT
+BEGIN:VEVENT
+UID:ebd5f2e7-7152-4161-83be-e4489b962ccc
+DTSTAMP:20220916T131746Z
+SUMMARY:WoT Discovery
+DTSTART;TZID=America/New_York:20220919T100000
+DTEND;TZID=America/New_York:20220919T110000
+DESCRIPTION:https://www.w3.org/events/meetings/ebd5f2e7-7152-4161-83be-e448
+ 9b962ccc/20220919T100000\n\nThe [WoT Discovery task force](https://www.w3.
+ org/WoT/IG/wiki/WG_WoT_Discovery_WebConf) is responsible for defining a di
+ stribution mechanism for WoT Thing Descriptions that can be used to facili
+ tate access to WoT Things and services while supporting security and priva
+ cy.\n\n[IRC: #wot-discovery](https://irc.w3.org/?channels=wot-discovery) /
+  [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2020Feb/0009.h
+ tml)
+STATUS:CANCELLED
+CREATED:20220916T131745Z
+LAST-MODIFIED:20220916T131746Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220919T100000
+END:VEVENT
+BEGIN:VEVENT
+UID:ebd5f2e7-7152-4161-83be-e4489b962ccc
+DTSTAMP:20221003T105927Z
+SUMMARY:WoT Discovery
+DTSTART;TZID=America/New_York:20221003T100000
+DTEND;TZID=America/New_York:20221003T110000
+DESCRIPTION:https://www.w3.org/events/meetings/ebd5f2e7-7152-4161-83be-e448
+ 9b962ccc/20221003T100000\n\nThe [WoT Discovery task force](https://www.w3.
+ org/WoT/IG/wiki/WG_WoT_Discovery_WebConf) is responsible for defining a di
+ stribution mechanism for WoT Thing Descriptions that can be used to facili
+ tate access to WoT Things and services while supporting security and priva
+ cy.\n\n[IRC: #wot-discovery](https://irc.w3.org/?channels=wot-discovery) /
+  [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2020Feb/0009.h
+ tml)
+STATUS:CANCELLED
+CREATED:20221003T105926Z
+LAST-MODIFIED:20221003T105927Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20221003T100000
+END:VEVENT
+BEGIN:VEVENT
+UID:ebd5f2e7-7152-4161-83be-e4489b962ccc
+DTSTAMP:20221127T180612Z
+SUMMARY:WoT Discovery
+DTSTART;TZID=America/New_York:20221128T100000
+DTEND;TZID=America/New_York:20221128T110000
+DESCRIPTION:https://www.w3.org/events/meetings/ebd5f2e7-7152-4161-83be-e448
+ 9b962ccc/20221128T100000\n\nThe [WoT Discovery task force](https://www.w3.
+ org/WoT/IG/wiki/WG_WoT_Discovery_WebConf) is responsible for defining a di
+ stribution mechanism for WoT Thing Descriptions that can be used to facili
+ tate access to WoT Things and services while supporting security and priva
+ cy.\n\n[IRC: #wot-discovery](https://irc.w3.org/?channels=wot-discovery) /
+  [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2020Feb/0009.h
+ tml)
+STATUS:CONFIRMED
+CREATED:20221127T180612Z
+LAST-MODIFIED:20221127T180612Z
+SEQUENCE:0
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20221128T100000
+END:VEVENT
+BEGIN:VEVENT
+UID:ebd5f2e7-7152-4161-83be-e4489b962ccc
+DTSTAMP:20221207T165713Z
+SUMMARY:WoT Discovery
+DTSTART;TZID=America/New_York:20221212T100000
+DTEND;TZID=America/New_York:20221212T110000
+DESCRIPTION:https://www.w3.org/events/meetings/ebd5f2e7-7152-4161-83be-e448
+ 9b962ccc/20221212T100000\n\nThe [WoT Discovery task force](https://www.w3.
+ org/WoT/IG/wiki/WG_WoT_Discovery_WebConf) is responsible for defining a di
+ stribution mechanism for WoT Thing Descriptions that can be used to facili
+ tate access to WoT Things and services while supporting security and priva
+ cy.\n\n[IRC: #wot-discovery](https://irc.w3.org/?channels=wot-discovery) /
+  [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2020Feb/0009.h
+ tml)
+STATUS:CANCELLED
+CREATED:20221207T165712Z
+LAST-MODIFIED:20221207T165713Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20221212T100000
+END:VEVENT
+BEGIN:VEVENT
+UID:ebd5f2e7-7152-4161-83be-e4489b962ccc
+DTSTAMP:20230111T112122Z
+SUMMARY:WoT Discovery
+DTSTART;TZID=America/New_York:20230116T100000
+DTEND;TZID=America/New_York:20230116T110000
+DESCRIPTION:https://www.w3.org/events/meetings/ebd5f2e7-7152-4161-83be-e448
+ 9b962ccc/20230116T100000\n\nThe [WoT Discovery task force](https://www.w3.
+ org/WoT/IG/wiki/WG_WoT_Discovery_WebConf) is responsible for defining a di
+ stribution mechanism for WoT Thing Descriptions that can be used to facili
+ tate access to WoT Things and services while supporting security and priva
+ cy.\n\n[IRC: #wot-discovery](https://irc.w3.org/?channels=wot-discovery) /
+  [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2020Feb/0009.h
+ tml)
+STATUS:CANCELLED
+CREATED:20230111T112121Z
+LAST-MODIFIED:20230111T112122Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20230116T100000
+END:VEVENT
+BEGIN:VEVENT
+UID:42c02811-3117-4a03-aec4-9a5789dbc78c
+DTSTAMP:20230529T104120Z
+SUMMARY:WoT Discovery
+DTSTART;TZID=America/New_York:20230123T100000
+DTEND;TZID=America/New_York:20230123T110000
+DESCRIPTION:https://www.w3.org/events/meetings/42c02811-3117-4a03-aec4-9a57
+ 89dbc78c\n\nThe [WoT Discovery task force](https://www.w3.org/WoT/IG/wiki/
+ WG_WoT_Discovery_WebConf) is responsible for defining a distribution mecha
+ nism for WoT Thing Descriptions that can be used to facilitate access to W
+ oT Things and services while supporting security and privacy.\n\n[IRC: #wo
+ t-discovery](https://irc.w3.org/?channels=wot-discovery) / [WebEx](https:/
+ /lists.w3.org/Archives/Member/member-wot-wg/2020Feb/0009.html)
+STATUS:CONFIRMED
+CREATED:20230201T170907Z
+LAST-MODIFIED:20230529T104120Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RELATED-TO:ebd5f2e7-7152-4161-83be-e4489b962ccc
+RELATED-TO:4ac673a8-5831-416d-aea2-aac708894c8c
+RRULE:FREQ=WEEKLY;UNTIL=20230522T140000Z;INTERVAL=1;BYDAY=MO;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:42c02811-3117-4a03-aec4-9a5789dbc78c
+DTSTAMP:20230201T170910Z
+SUMMARY:WoT Discovery
+DTSTART;TZID=America/New_York:20230130T100000
+DTEND;TZID=America/New_York:20230130T110000
+DESCRIPTION:https://www.w3.org/events/meetings/42c02811-3117-4a03-aec4-9a57
+ 89dbc78c/20230130T100000\n\nThe [WoT Discovery task force](https://www.w3.
+ org/WoT/IG/wiki/WG_WoT_Discovery_WebConf) is responsible for defining a di
+ stribution mechanism for WoT Thing Descriptions that can be used to facili
+ tate access to WoT Things and services while supporting security and priva
+ cy.\n\n[IRC: #wot-discovery](https://irc.w3.org/?channels=wot-discovery) /
+  [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2020Feb/0009.h
+ tml)
+STATUS:CANCELLED
+CREATED:20230127T164003Z
+LAST-MODIFIED:20230201T170910Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20230130T100000
+END:VEVENT
+BEGIN:VEVENT
+UID:42c02811-3117-4a03-aec4-9a5789dbc78c
+DTSTAMP:20230201T172857Z
+SUMMARY:CANCELLED WoT Discovery
+DTSTART;TZID=America/New_York:20230206T100000
+DTEND;TZID=America/New_York:20230206T110000
+DESCRIPTION:https://www.w3.org/events/meetings/42c02811-3117-4a03-aec4-9a57
+ 89dbc78c/20230206T100000\n\nThe [WoT Discovery task force](https://www.w3.
+ org/WoT/IG/wiki/WG_WoT_Discovery_WebConf) is responsible for defining a di
+ stribution mechanism for WoT Thing Descriptions that can be used to facili
+ tate access to WoT Things and services while supporting security and priva
+ cy.\n\n[IRC: #wot-discovery](https://irc.w3.org/?channels=wot-discovery) /
+  [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2020Feb/0009.h
+ tml)
+STATUS:TENTATIVE
+CREATED:20230201T172819Z
+LAST-MODIFIED:20230201T172857Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20230206T100000
+END:VEVENT
+BEGIN:VEVENT
+UID:42c02811-3117-4a03-aec4-9a5789dbc78c
+DTSTAMP:20230212T225446Z
+SUMMARY:CANCELLED WoT Discovery
+DTSTART;TZID=America/New_York:20230213T100000
+DTEND;TZID=America/New_York:20230213T110000
+DESCRIPTION:https://www.w3.org/events/meetings/42c02811-3117-4a03-aec4-9a57
+ 89dbc78c/20230213T100000\n\nThe [WoT Discovery task force](https://www.w3.
+ org/WoT/IG/wiki/WG_WoT_Discovery_WebConf) is responsible for defining a di
+ stribution mechanism for WoT Thing Descriptions that can be used to facili
+ tate access to WoT Things and services while supporting security and priva
+ cy.\n\n[IRC: #wot-discovery](https://irc.w3.org/?channels=wot-discovery) /
+  [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2020Feb/0009.h
+ tml)
+STATUS:TENTATIVE
+CREATED:20230212T225445Z
+LAST-MODIFIED:20230212T225446Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20230213T100000
+END:VEVENT
+BEGIN:VEVENT
+UID:42c02811-3117-4a03-aec4-9a5789dbc78c
+DTSTAMP:20230223T123741Z
+SUMMARY:WoT <strike>Discovery</strike> Charter
+DTSTART;TZID=America/New_York:20230227T100000
+DTEND;TZID=America/New_York:20230227T110000
+DESCRIPTION:https://www.w3.org/events/meetings/42c02811-3117-4a03-aec4-9a57
+ 89dbc78c/20230227T100000\n\nThis occurrence will be re-purposed to work on
+  the draft WG charter.\n\nThe [WoT Discovery task force](https://www.w3.or
+ g/WoT/IG/wiki/WG_WoT_Discovery_WebConf) is responsible for defining a dist
+ ribution mechanism for WoT Thing Descriptions that can be used to facilita
+ te access to WoT Things and services while supporting security and privacy
+ .\n\n[IRC: #wot-discovery](https://irc.w3.org/?channels=wot-discovery) / [
+ WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2020Feb/0009.htm
+ l)
+STATUS:CONFIRMED
+CREATED:20230223T123740Z
+LAST-MODIFIED:20230223T123741Z
+SEQUENCE:0
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20230227T100000
+END:VEVENT
+BEGIN:VEVENT
+UID:4ac673a8-5831-416d-aea2-aac708894c8c
+DTSTAMP:20230529T104120Z
+SUMMARY:WoT Discovery
+DTSTART;TZID=America/New_York:20230529T100000
+DTEND;TZID=America/New_York:20230529T110000
+DESCRIPTION:https://www.w3.org/events/meetings/4ac673a8-5831-416d-aea2-aac7
+ 08894c8c\n\nThe [WoT Discovery task force](https://www.w3.org/WoT/IG/wiki/
+ WG_WoT_Discovery_WebConf) is responsible for defining a distribution mecha
+ nism for WoT Thing Descriptions that can be used to facilitate access to W
+ oT Things and services while supporting security and privacy.
+STATUS:CONFIRMED
+CREATED:20230529T104120Z
+LAST-MODIFIED:20230529T104120Z
+SEQUENCE:0
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:Zoom
+RELATED-TO:42c02811-3117-4a03-aec4-9a5789dbc78c
+RRULE:FREQ=WEEKLY;UNTIL=20230801T140000Z;INTERVAL=1;BYDAY=MO;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:ba8417c2-d075-4e43-bde4-88f0d03c6cf3
+DTSTAMP:20220307T162926Z
+SUMMARY:WoT Marketing
+DTSTART;TZID=America/New_York:20220301T070000
+DTEND;TZID=America/New_York:20220301T080000
+DESCRIPTION:https://www.w3.org/events/meetings/ba8417c2-d075-4e43-bde4-88f0
+ d03c6cf3\n\nThe [WoT Marketing task force](https://www.w3.org/WoT/IG/wiki/
+ Marketing_WebConf) is responsible for reaching out and collaborating with 
+ the community to increase the adoption of the WoT. The Marketing Task Forc
+ e works on promoting the W3C Web of Things in different ways such as Web p
+ resence\, Social Media presence\, and more.\n\n[IRC: #wot-marketing](https
+ ://irc.w3.org/?channels=wot-marketing) / [WebEx](https://lists.w3.org/Arch
+ ives/Member/member-wot-wg/2020Aug/0024.html)
+STATUS:CONFIRMED
+CREATED:20220301T202432Z
+LAST-MODIFIED:20220307T162926Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RRULE:FREQ=WEEKLY;UNTIL=20220301T120000Z;INTERVAL=1;BYDAY=TU;WKST=MO
+RELATED-TO:3ecdcb15-3e15-4487-93a8-f9ecfbb899d1
+END:VEVENT
+BEGIN:VEVENT
+UID:3ecdcb15-3e15-4487-93a8-f9ecfbb899d1
+DTSTAMP:20221019T125253Z
+SUMMARY:WoT Marketing
+DTSTART;TZID=America/New_York:20220308T070000
+DTEND;TZID=America/New_York:20220308T080000
+DESCRIPTION:https://www.w3.org/events/meetings/3ecdcb15-3e15-4487-93a8-f9ec
+ fbb899d1\n\nThe [WoT Marketing task force](https://www.w3.org/WoT/IG/wiki/
+ Marketing_WebConf) is responsible for reaching out and collaborating with 
+ the community to increase the adoption of the WoT. The Marketing Task Forc
+ e works on promoting the W3C Web of Things in different ways such as Web p
+ resence\, Social Media presence\, and more.\n\n[IRC: #wot-marketing](https
+ ://irc.w3.org/?channels=wot-marketing) / [WebEx](https://lists.w3.org/Arch
+ ives/Member/member-wot-wg/2020Aug/0024.html)
+STATUS:CONFIRMED
+CREATED:20220307T162926Z
+LAST-MODIFIED:20221019T125253Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RELATED-TO:ba8417c2-d075-4e43-bde4-88f0d03c6cf3
+RELATED-TO:5f92972c-c4ed-45c3-a341-a392af457993
+RRULE:FREQ=WEEKLY;UNTIL=20221018T110000Z;INTERVAL=1;BYDAY=TU;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:3ecdcb15-3e15-4487-93a8-f9ecfbb899d1
+DTSTAMP:20220309T152215Z
+SUMMARY:WoT Marketing
+DTSTART;TZID=America/New_York:20220315T070000
+DTEND;TZID=America/New_York:20220315T080000
+DESCRIPTION:https://www.w3.org/events/meetings/3ecdcb15-3e15-4487-93a8-f9ec
+ fbb899d1/20220315T070000\n\nThe [WoT Marketing task force](https://www.w3.
+ org/WoT/IG/wiki/Marketing_WebConf) is responsible for reaching out and col
+ laborating with the community to increase the adoption of the WoT. The Mar
+ keting Task Force works on promoting the W3C Web of Things in different wa
+ ys such as Web presence\, Social Media presence\, and more.\n\n[IRC: #wot-
+ marketing](https://irc.w3.org/?channels=wot-marketing) / [WebEx](https://l
+ ists.w3.org/Archives/Member/member-wot-wg/2020Aug/0024.html)
+STATUS:CANCELLED
+CREATED:20220309T152213Z
+LAST-MODIFIED:20220309T152215Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220315T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:3ecdcb15-3e15-4487-93a8-f9ecfbb899d1
+DTSTAMP:20220527T175235Z
+SUMMARY:WoT Marketing
+DTSTART;TZID=America/New_York:20220531T070000
+DTEND;TZID=America/New_York:20220531T080000
+DESCRIPTION:https://www.w3.org/events/meetings/3ecdcb15-3e15-4487-93a8-f9ec
+ fbb899d1/20220531T070000\n\nThe [WoT Marketing task force](https://www.w3.
+ org/WoT/IG/wiki/Marketing_WebConf) is responsible for reaching out and col
+ laborating with the community to increase the adoption of the WoT. The Mar
+ keting Task Force works on promoting the W3C Web of Things in different wa
+ ys such as Web presence\, Social Media presence\, and more.\n\n[IRC: #wot-
+ marketing](https://irc.w3.org/?channels=wot-marketing) / [WebEx](https://l
+ ists.w3.org/Archives/Member/member-wot-wg/2020Aug/0024.html)
+STATUS:CANCELLED
+CREATED:20220527T175234Z
+LAST-MODIFIED:20220527T175235Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220531T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:3ecdcb15-3e15-4487-93a8-f9ecfbb899d1
+DTSTAMP:20220621T110418Z
+SUMMARY:WoT Marketing
+DTSTART;TZID=America/New_York:20220621T070000
+DTEND;TZID=America/New_York:20220621T080000
+DESCRIPTION:https://www.w3.org/events/meetings/3ecdcb15-3e15-4487-93a8-f9ec
+ fbb899d1/20220621T070000\n\nThe [WoT Marketing task force](https://www.w3.
+ org/WoT/IG/wiki/Marketing_WebConf) is responsible for reaching out and col
+ laborating with the community to increase the adoption of the WoT. The Mar
+ keting Task Force works on promoting the W3C Web of Things in different wa
+ ys such as Web presence\, Social Media presence\, and more.\n\n[IRC: #wot-
+ marketing](https://irc.w3.org/?channels=wot-marketing) / [WebEx](https://l
+ ists.w3.org/Archives/Member/member-wot-wg/2020Aug/0024.html)
+STATUS:CANCELLED
+CREATED:20220621T110417Z
+LAST-MODIFIED:20220621T110418Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220621T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:3ecdcb15-3e15-4487-93a8-f9ecfbb899d1
+DTSTAMP:20220621T110451Z
+SUMMARY:WoT Marketing
+DTSTART;TZID=America/New_York:20220628T070000
+DTEND;TZID=America/New_York:20220628T080000
+DESCRIPTION:https://www.w3.org/events/meetings/3ecdcb15-3e15-4487-93a8-f9ec
+ fbb899d1/20220628T070000\n\nThe [WoT Marketing task force](https://www.w3.
+ org/WoT/IG/wiki/Marketing_WebConf) is responsible for reaching out and col
+ laborating with the community to increase the adoption of the WoT. The Mar
+ keting Task Force works on promoting the W3C Web of Things in different wa
+ ys such as Web presence\, Social Media presence\, and more.\n\n[IRC: #wot-
+ marketing](https://irc.w3.org/?channels=wot-marketing) / [WebEx](https://l
+ ists.w3.org/Archives/Member/member-wot-wg/2020Aug/0024.html)
+STATUS:CANCELLED
+CREATED:20220621T110450Z
+LAST-MODIFIED:20220621T110451Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220628T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:3ecdcb15-3e15-4487-93a8-f9ecfbb899d1
+DTSTAMP:20220719T102822Z
+SUMMARY:WoT Marketing
+DTSTART;TZID=America/New_York:20220719T073000
+DTEND;TZID=America/New_York:20220719T080000
+DESCRIPTION:https://www.w3.org/events/meetings/3ecdcb15-3e15-4487-93a8-f9ec
+ fbb899d1/20220719T070000\n\nThe [WoT Marketing task force](https://www.w3.
+ org/WoT/IG/wiki/Marketing_WebConf) is responsible for reaching out and col
+ laborating with the community to increase the adoption of the WoT. The Mar
+ keting Task Force works on promoting the W3C Web of Things in different wa
+ ys such as Web presence\, Social Media presence\, and more.\n\n[IRC: #wot-
+ marketing](https://irc.w3.org/?channels=wot-marketing) / [WebEx](https://l
+ ists.w3.org/Archives/Member/member-wot-wg/2020Aug/0024.html)
+STATUS:CONFIRMED
+CREATED:20220719T102821Z
+LAST-MODIFIED:20220719T102822Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220719T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:3ecdcb15-3e15-4487-93a8-f9ecfbb899d1
+DTSTAMP:20220720T144045Z
+SUMMARY:WoT Marketing
+DTSTART;TZID=America/New_York:20220726T070000
+DTEND;TZID=America/New_York:20220726T080000
+DESCRIPTION:https://www.w3.org/events/meetings/3ecdcb15-3e15-4487-93a8-f9ec
+ fbb899d1/20220726T070000\n\nThe [WoT Marketing task force](https://www.w3.
+ org/WoT/IG/wiki/Marketing_WebConf) is responsible for reaching out and col
+ laborating with the community to increase the adoption of the WoT. The Mar
+ keting Task Force works on promoting the W3C Web of Things in different wa
+ ys such as Web presence\, Social Media presence\, and more.\n\n[IRC: #wot-
+ marketing](https://irc.w3.org/?channels=wot-marketing) / [WebEx](https://l
+ ists.w3.org/Archives/Member/member-wot-wg/2020Aug/0024.html)
+STATUS:CANCELLED
+CREATED:20220720T144044Z
+LAST-MODIFIED:20220720T144045Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220726T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:3ecdcb15-3e15-4487-93a8-f9ecfbb899d1
+DTSTAMP:20220810T100824Z
+SUMMARY:WoT Marketing
+DTSTART;TZID=America/New_York:20220823T070000
+DTEND;TZID=America/New_York:20220823T080000
+DESCRIPTION:https://www.w3.org/events/meetings/3ecdcb15-3e15-4487-93a8-f9ec
+ fbb899d1/20220823T070000\n\nThe [WoT Marketing task force](https://www.w3.
+ org/WoT/IG/wiki/Marketing_WebConf) is responsible for reaching out and col
+ laborating with the community to increase the adoption of the WoT. The Mar
+ keting Task Force works on promoting the W3C Web of Things in different wa
+ ys such as Web presence\, Social Media presence\, and more.\n\n[IRC: #wot-
+ marketing](https://irc.w3.org/?channels=wot-marketing) / [WebEx](https://l
+ ists.w3.org/Archives/Member/member-wot-wg/2020Aug/0024.html)
+STATUS:CANCELLED
+CREATED:20220810T100822Z
+LAST-MODIFIED:20220810T100824Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220823T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:3ecdcb15-3e15-4487-93a8-f9ecfbb899d1
+DTSTAMP:20220810T100903Z
+SUMMARY:WoT Marketing
+DTSTART;TZID=America/New_York:20220830T070000
+DTEND;TZID=America/New_York:20220830T080000
+DESCRIPTION:https://www.w3.org/events/meetings/3ecdcb15-3e15-4487-93a8-f9ec
+ fbb899d1/20220830T070000\n\nThe [WoT Marketing task force](https://www.w3.
+ org/WoT/IG/wiki/Marketing_WebConf) is responsible for reaching out and col
+ laborating with the community to increase the adoption of the WoT. The Mar
+ keting Task Force works on promoting the W3C Web of Things in different wa
+ ys such as Web presence\, Social Media presence\, and more.\n\n[IRC: #wot-
+ marketing](https://irc.w3.org/?channels=wot-marketing) / [WebEx](https://l
+ ists.w3.org/Archives/Member/member-wot-wg/2020Aug/0024.html)
+STATUS:CANCELLED
+CREATED:20220810T100902Z
+LAST-MODIFIED:20220810T100903Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220830T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:3ecdcb15-3e15-4487-93a8-f9ecfbb899d1
+DTSTAMP:20220831T161246Z
+SUMMARY:WoT Marketing
+DTSTART;TZID=America/New_York:20220906T070000
+DTEND;TZID=America/New_York:20220906T080000
+DESCRIPTION:https://www.w3.org/events/meetings/3ecdcb15-3e15-4487-93a8-f9ec
+ fbb899d1/20220906T070000\n\nThe [WoT Marketing task force](https://www.w3.
+ org/WoT/IG/wiki/Marketing_WebConf) is responsible for reaching out and col
+ laborating with the community to increase the adoption of the WoT. The Mar
+ keting Task Force works on promoting the W3C Web of Things in different wa
+ ys such as Web presence\, Social Media presence\, and more.\n\n[IRC: #wot-
+ marketing](https://irc.w3.org/?channels=wot-marketing) / [WebEx](https://l
+ ists.w3.org/Archives/Member/member-wot-wg/2020Aug/0024.html)
+STATUS:CANCELLED
+CREATED:20220831T161245Z
+LAST-MODIFIED:20220831T161246Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220906T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:3ecdcb15-3e15-4487-93a8-f9ecfbb899d1
+DTSTAMP:20220831T161920Z
+SUMMARY:WoT Marketing
+DTSTART;TZID=America/New_York:20220913T070000
+DTEND;TZID=America/New_York:20220913T080000
+DESCRIPTION:https://www.w3.org/events/meetings/3ecdcb15-3e15-4487-93a8-f9ec
+ fbb899d1/20220913T070000\n\nThe [WoT Marketing task force](https://www.w3.
+ org/WoT/IG/wiki/Marketing_WebConf) is responsible for reaching out and col
+ laborating with the community to increase the adoption of the WoT. The Mar
+ keting Task Force works on promoting the W3C Web of Things in different wa
+ ys such as Web presence\, Social Media presence\, and more.\n\n[IRC: #wot-
+ marketing](https://irc.w3.org/?channels=wot-marketing) / [WebEx](https://l
+ ists.w3.org/Archives/Member/member-wot-wg/2020Aug/0024.html)
+STATUS:CANCELLED
+CREATED:20220831T161918Z
+LAST-MODIFIED:20220831T161920Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220913T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:3ecdcb15-3e15-4487-93a8-f9ecfbb899d1
+DTSTAMP:20220916T131810Z
+SUMMARY:WoT Marketing
+DTSTART;TZID=America/New_York:20220920T070000
+DTEND;TZID=America/New_York:20220920T080000
+DESCRIPTION:https://www.w3.org/events/meetings/3ecdcb15-3e15-4487-93a8-f9ec
+ fbb899d1/20220920T070000\n\nThe [WoT Marketing task force](https://www.w3.
+ org/WoT/IG/wiki/Marketing_WebConf) is responsible for reaching out and col
+ laborating with the community to increase the adoption of the WoT. The Mar
+ keting Task Force works on promoting the W3C Web of Things in different wa
+ ys such as Web presence\, Social Media presence\, and more.\n\n[IRC: #wot-
+ marketing](https://irc.w3.org/?channels=wot-marketing) / [WebEx](https://l
+ ists.w3.org/Archives/Member/member-wot-wg/2020Aug/0024.html)
+STATUS:CANCELLED
+CREATED:20220916T131809Z
+LAST-MODIFIED:20220916T131810Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220920T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:3ecdcb15-3e15-4487-93a8-f9ecfbb899d1
+DTSTAMP:20221003T110009Z
+SUMMARY:WoT Marketing
+DTSTART;TZID=America/New_York:20221004T070000
+DTEND;TZID=America/New_York:20221004T080000
+DESCRIPTION:https://www.w3.org/events/meetings/3ecdcb15-3e15-4487-93a8-f9ec
+ fbb899d1/20221004T070000\n\nThe [WoT Marketing task force](https://www.w3.
+ org/WoT/IG/wiki/Marketing_WebConf) is responsible for reaching out and col
+ laborating with the community to increase the adoption of the WoT. The Mar
+ keting Task Force works on promoting the W3C Web of Things in different wa
+ ys such as Web presence\, Social Media presence\, and more.\n\n[IRC: #wot-
+ marketing](https://irc.w3.org/?channels=wot-marketing) / [WebEx](https://l
+ ists.w3.org/Archives/Member/member-wot-wg/2020Aug/0024.html)
+STATUS:CANCELLED
+CREATED:20221003T110008Z
+LAST-MODIFIED:20221003T110009Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20221004T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:5f92972c-c4ed-45c3-a341-a392af457993
+DTSTAMP:20221123T163911Z
+SUMMARY:WoT Marketing
+DTSTART;TZID=America/New_York:20221025T070000
+DTEND;TZID=America/New_York:20221025T080000
+DESCRIPTION:https://www.w3.org/events/meetings/5f92972c-c4ed-45c3-a341-a392
+ af457993\n\nThe [WoT Marketing task force](https://www.w3.org/WoT/IG/wiki/
+ Marketing_WebConf) is responsible for reaching out and collaborating with 
+ the community to increase the adoption of the WoT. The Marketing Task Forc
+ e works on promoting the W3C Web of Things in different ways such as Web p
+ resence\, Social Media presence\, and more.\n\n[IRC: #wot-marketing](https
+ ://irc.w3.org/?channels=wot-marketing) / [WebEx](https://lists.w3.org/Arch
+ ives/Member/member-wot-wg/2020Aug/0024.html)
+STATUS:CONFIRMED
+CREATED:20221019T125253Z
+LAST-MODIFIED:20221123T163911Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RELATED-TO:3ecdcb15-3e15-4487-93a8-f9ecfbb899d1
+RELATED-TO:4ae4577c-5585-42ef-a2b2-f3899cb95cb0
+RRULE:FREQ=WEEKLY;UNTIL=20221122T120000Z;INTERVAL=1;BYDAY=TU;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:5f92972c-c4ed-45c3-a341-a392af457993
+DTSTAMP:20221026T121626Z
+SUMMARY:WoT Marketing
+DTSTART;TZID=America/New_York:20221101T070000
+DTEND;TZID=America/New_York:20221101T080000
+DESCRIPTION:https://www.w3.org/events/meetings/5f92972c-c4ed-45c3-a341-a392
+ af457993/20221101T070000\n\nThe [WoT Marketing task force](https://www.w3.
+ org/WoT/IG/wiki/Marketing_WebConf) is responsible for reaching out and col
+ laborating with the community to increase the adoption of the WoT. The Mar
+ keting Task Force works on promoting the W3C Web of Things in different wa
+ ys such as Web presence\, Social Media presence\, and more.\n\n[IRC: #wot-
+ marketing](https://irc.w3.org/?channels=wot-marketing) / [WebEx](https://l
+ ists.w3.org/Archives/Member/member-wot-wg/2020Aug/0024.html)
+STATUS:CANCELLED
+CREATED:20221026T121625Z
+LAST-MODIFIED:20221026T121626Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20221101T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:4ae4577c-5585-42ef-a2b2-f3899cb95cb0
+DTSTAMP:20221213T125217Z
+SUMMARY:WoT Marketing
+DTSTART;TZID=America/New_York:20221129T073000
+DTEND;TZID=America/New_York:20221129T080000
+DESCRIPTION:https://www.w3.org/events/meetings/4ae4577c-5585-42ef-a2b2-f389
+ 9cb95cb0\n\nThe [WoT Marketing task force](https://www.w3.org/WoT/IG/wiki/
+ Marketing_WebConf) is responsible for reaching out and collaborating with 
+ the community to increase the adoption of the WoT. The Marketing Task Forc
+ e works on promoting the W3C Web of Things in different ways such as Web p
+ resence\, Social Media presence\, and more.\n\n[IRC: #wot-marketing](https
+ ://irc.w3.org/?channels=wot-marketing) / [WebEx](https://lists.w3.org/Arch
+ ives/Member/member-wot-wg/2020Aug/0024.html)
+STATUS:CONFIRMED
+CREATED:20221123T163909Z
+LAST-MODIFIED:20221213T125217Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RELATED-TO:5f92972c-c4ed-45c3-a341-a392af457993
+RELATED-TO:45cf6f40-47f5-42bc-92f9-62196c437568
+RRULE:FREQ=WEEKLY;UNTIL=20221206T123000Z;INTERVAL=1;BYDAY=TU;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:4ae4577c-5585-42ef-a2b2-f3899cb95cb0
+DTSTAMP:20221205T222651Z
+SUMMARY:Special WoT Marketing
+DTSTART;TZID=America/New_York:20221206T073000
+DTEND;TZID=America/New_York:20221206T080000
+DESCRIPTION:https://www.w3.org/events/meetings/4ae4577c-5585-42ef-a2b2-f389
+ 9cb95cb0/20221206T073000\n\nMeeting with Chairs and Team Contact\nThe [WoT
+  Marketing task force](https://www.w3.org/WoT/IG/wiki/Marketing_WebConf) i
+ s responsible for reaching out and collaborating with the community to inc
+ rease the adoption of the WoT. The Marketing Task Force works on promoting
+  the W3C Web of Things in different ways such as Web presence\, Social Med
+ ia presence\, and more.\n\n[IRC: #wot-marketing](https://irc.w3.org/?chann
+ els=wot-marketing) / [WebEx](https://lists.w3.org/Archives/Member/member-w
+ ot-wg/2020Aug/0024.html)
+STATUS:CONFIRMED
+CREATED:20221123T164352Z
+LAST-MODIFIED:20221205T222651Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20221206T073000
+END:VEVENT
+BEGIN:VEVENT
+UID:45cf6f40-47f5-42bc-92f9-62196c437568
+DTSTAMP:20230529T104710Z
+SUMMARY:WoT Marketing
+DTSTART;TZID=America/New_York:20221213T073000
+DTEND;TZID=America/New_York:20221213T080000
+DESCRIPTION:https://www.w3.org/events/meetings/45cf6f40-47f5-42bc-92f9-6219
+ 6c437568\n\nNow with the Microsoft Teams link. Testing for one week and th
+ en changing the rest.\n\nThe [WoT Marketing task force](https://www.w3.org
+ /WoT/IG/wiki/Marketing_WebConf) is responsible for reaching out and collab
+ orating with the community to increase the adoption of the WoT. The Market
+ ing Task Force works on promoting the W3C Web of Things in different ways 
+ such as Web presence\, Social Media presence\, and more.\n\n[IRC: #wot-mar
+ keting](https://irc.w3.org/?channels=wot-marketing)\n\nAgenda: https://www
+ .w3.org/WoT/IG/wiki/Marketing_WebConf#Agendas
+STATUS:CONFIRMED
+CREATED:20221206T150206Z
+LAST-MODIFIED:20230529T104710Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:Teams
+RELATED-TO:4ae4577c-5585-42ef-a2b2-f3899cb95cb0
+RELATED-TO:bf5f8407-1b4e-4931-b149-e7d71f85a938
+RRULE:FREQ=WEEKLY;UNTIL=20230523T113000Z;INTERVAL=1;BYDAY=TU;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:45cf6f40-47f5-42bc-92f9-62196c437568
+DTSTAMP:20221213T125218Z
+SUMMARY:WoT Marketing
+DTSTART;TZID=America/New_York:20230103T073000
+DTEND;TZID=America/New_York:20230103T080000
+DESCRIPTION:https://www.w3.org/events/meetings/45cf6f40-47f5-42bc-92f9-6219
+ 6c437568/20230103T073000\n\nNow with the Microsoft Teams link. Testing for
+  one week and then changing the rest.\n\nThe [WoT Marketing task force](ht
+ tps://www.w3.org/WoT/IG/wiki/Marketing_WebConf) is responsible for reachin
+ g out and collaborating with the community to increase the adoption of the
+  WoT. The Marketing Task Force works on promoting the W3C Web of Things in
+  different ways such as Web presence\, Social Media presence\, and more.\n
+ \n[IRC: #wot-marketing](https://irc.w3.org/?channels=wot-marketing)\n\nAge
+ nda: https://www.w3.org/WoT/IG/wiki/Marketing_WebConf#Agendas
+STATUS:CANCELLED
+CREATED:20221123T164502Z
+LAST-MODIFIED:20221213T125218Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:Teams
+RECURRENCE-ID;TZID=America/New_York:20230103T073000
+END:VEVENT
+BEGIN:VEVENT
+UID:45cf6f40-47f5-42bc-92f9-62196c437568
+DTSTAMP:20221213T125219Z
+SUMMARY:WoT Marketing
+DTSTART;TZID=America/New_York:20230110T073000
+DTEND;TZID=America/New_York:20230110T080000
+DESCRIPTION:https://www.w3.org/events/meetings/45cf6f40-47f5-42bc-92f9-6219
+ 6c437568/20230110T073000\n\nNow with the Microsoft Teams link. Testing for
+  one week and then changing the rest.\n\nThe [WoT Marketing task force](ht
+ tps://www.w3.org/WoT/IG/wiki/Marketing_WebConf) is responsible for reachin
+ g out and collaborating with the community to increase the adoption of the
+  WoT. The Marketing Task Force works on promoting the W3C Web of Things in
+  different ways such as Web presence\, Social Media presence\, and more.\n
+ \n[IRC: #wot-marketing](https://irc.w3.org/?channels=wot-marketing)\n\nAge
+ nda: https://www.w3.org/WoT/IG/wiki/Marketing_WebConf#Agendas
+STATUS:CANCELLED
+CREATED:20221123T164526Z
+LAST-MODIFIED:20221213T125219Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:Teams
+RECURRENCE-ID;TZID=America/New_York:20230110T073000
+END:VEVENT
+BEGIN:VEVENT
+UID:45cf6f40-47f5-42bc-92f9-62196c437568
+DTSTAMP:20221213T125221Z
+SUMMARY:WoT Marketing
+DTSTART;TZID=America/New_York:20221227T073000
+DTEND;TZID=America/New_York:20221227T080000
+DESCRIPTION:https://www.w3.org/events/meetings/45cf6f40-47f5-42bc-92f9-6219
+ 6c437568/20221227T073000\n\nNow with the Microsoft Teams link. Testing for
+  one week and then changing the rest.\n\nThe [WoT Marketing task force](ht
+ tps://www.w3.org/WoT/IG/wiki/Marketing_WebConf) is responsible for reachin
+ g out and collaborating with the community to increase the adoption of the
+  WoT. The Marketing Task Force works on promoting the W3C Web of Things in
+  different ways such as Web presence\, Social Media presence\, and more.\n
+ \n[IRC: #wot-marketing](https://irc.w3.org/?channels=wot-marketing)\n\nAge
+ nda: https://www.w3.org/WoT/IG/wiki/Marketing_WebConf#Agendas
+STATUS:CANCELLED
+CREATED:20221123T164833Z
+LAST-MODIFIED:20221213T125221Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:Teams
+RECURRENCE-ID;TZID=America/New_York:20221227T073000
+END:VEVENT
+BEGIN:VEVENT
+UID:45cf6f40-47f5-42bc-92f9-62196c437568
+DTSTAMP:20230111T112154Z
+SUMMARY:WoT Marketing
+DTSTART;TZID=America/New_York:20230117T073000
+DTEND;TZID=America/New_York:20230117T080000
+DESCRIPTION:https://www.w3.org/events/meetings/45cf6f40-47f5-42bc-92f9-6219
+ 6c437568/20230117T073000\n\nNow with the Microsoft Teams link. Testing for
+  one week and then changing the rest.\n\nThe [WoT Marketing task force](ht
+ tps://www.w3.org/WoT/IG/wiki/Marketing_WebConf) is responsible for reachin
+ g out and collaborating with the community to increase the adoption of the
+  WoT. The Marketing Task Force works on promoting the W3C Web of Things in
+  different ways such as Web presence\, Social Media presence\, and more.\n
+ \n[IRC: #wot-marketing](https://irc.w3.org/?channels=wot-marketing)\n\nAge
+ nda: https://www.w3.org/WoT/IG/wiki/Marketing_WebConf#Agendas
+STATUS:CANCELLED
+CREATED:20230111T112153Z
+LAST-MODIFIED:20230111T112154Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:Teams
+RECURRENCE-ID;TZID=America/New_York:20230117T073000
+END:VEVENT
+BEGIN:VEVENT
+UID:45cf6f40-47f5-42bc-92f9-62196c437568
+DTSTAMP:20230131T124058Z
+SUMMARY:WoT Marketing - First of the Month
+DTSTART;TZID=America/New_York:20230207T073000
+DTEND;TZID=America/New_York:20230207T080000
+DESCRIPTION:https://www.w3.org/events/meetings/45cf6f40-47f5-42bc-92f9-6219
+ 6c437568/20230207T073000\n\nThe [WoT Marketing task force](https://www.w3.
+ org/WoT/IG/wiki/Marketing_WebConf) is responsible for reaching out and col
+ laborating with the community to increase the adoption of the WoT. The Mar
+ keting Task Force works on promoting the W3C Web of Things in different wa
+ ys such as Web presence\, Social Media presence\, and more.\n\n[IRC: #wot-
+ marketing](https://irc.w3.org/?channels=wot-marketing) / [WebEx](https://l
+ ists.w3.org/Archives/Member/member-wot-wg/2020Aug/0024.html)\n\nAgenda: ht
+ tps://www.w3.org/WoT/IG/wiki/Marketing_WebConf#Agendas
+STATUS:CONFIRMED
+CREATED:20230131T124057Z
+LAST-MODIFIED:20230131T124058Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20230207T073000
+END:VEVENT
+BEGIN:VEVENT
+UID:45cf6f40-47f5-42bc-92f9-62196c437568
+DTSTAMP:20230201T132251Z
+SUMMARY:CANCELLED WoT Marketing
+DTSTART;TZID=America/New_York:20230214T073000
+DTEND;TZID=America/New_York:20230214T080000
+DESCRIPTION:https://www.w3.org/events/meetings/45cf6f40-47f5-42bc-92f9-6219
+ 6c437568/20230214T073000\n\nNow with the Microsoft Teams link. Testing for
+  one week and then changing the rest.\n\nThe [WoT Marketing task force](ht
+ tps://www.w3.org/WoT/IG/wiki/Marketing_WebConf) is responsible for reachin
+ g out and collaborating with the community to increase the adoption of the
+  WoT. The Marketing Task Force works on promoting the W3C Web of Things in
+  different ways such as Web presence\, Social Media presence\, and more.\n
+ \n[IRC: #wot-marketing](https://irc.w3.org/?channels=wot-marketing)\n\nAge
+ nda: https://www.w3.org/WoT/IG/wiki/Marketing_WebConf#Agendas
+STATUS:TENTATIVE
+CREATED:20230201T132250Z
+LAST-MODIFIED:20230201T132251Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:Teams
+RECURRENCE-ID;TZID=America/New_York:20230214T073000
+END:VEVENT
+BEGIN:VEVENT
+UID:45cf6f40-47f5-42bc-92f9-62196c437568
+DTSTAMP:20230207T130238Z
+SUMMARY:WoT Marketing - First of the Month
+DTSTART;TZID=America/New_York:20230228T073000
+DTEND;TZID=America/New_York:20230228T080000
+DESCRIPTION:https://www.w3.org/events/meetings/45cf6f40-47f5-42bc-92f9-6219
+ 6c437568/20230307T073000\n\nMOVED 1 WEEK IN ADVANCE\n\nThe [WoT Marketing 
+ task force](https://www.w3.org/WoT/IG/wiki/Marketing_WebConf) is responsib
+ le for reaching out and collaborating with the community to increase the a
+ doption of the WoT. The Marketing Task Force works on promoting the W3C We
+ b of Things in different ways such as Web presence\, Social Media presence
+ \, and more.\n\n[IRC: #wot-marketing](https://irc.w3.org/?channels=wot-mar
+ keting) / [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2020A
+ ug/0024.html)\n\nAgenda: https://www.w3.org/WoT/IG/wiki/Marketing_WebConf#
+ Agendas
+STATUS:CONFIRMED
+CREATED:20230207T130237Z
+LAST-MODIFIED:20230207T130238Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20230307T073000
+END:VEVENT
+BEGIN:VEVENT
+UID:45cf6f40-47f5-42bc-92f9-62196c437568
+DTSTAMP:20230207T130337Z
+SUMMARY:REPLACED WoT Marketing
+DTSTART;TZID=America/New_York:20230228T073000
+DTEND;TZID=America/New_York:20230228T080000
+DESCRIPTION:https://www.w3.org/events/meetings/45cf6f40-47f5-42bc-92f9-6219
+ 6c437568/20230228T073000\n\nSee https://www.w3.org/events/meetings/45cf6f4
+ 0-47f5-42bc-92f9-62196c437568/20230307T073000\n\nNow with the Microsoft Te
+ ams link. Testing for one week and then changing the rest.\n\nThe [WoT Mar
+ keting task force](https://www.w3.org/WoT/IG/wiki/Marketing_WebConf) is re
+ sponsible for reaching out and collaborating with the community to increas
+ e the adoption of the WoT. The Marketing Task Force works on promoting the
+  W3C Web of Things in different ways such as Web presence\, Social Media p
+ resence\, and more.\n\n[IRC: #wot-marketing](https://irc.w3.org/?channels=
+ wot-marketing)\n\nAgenda: https://www.w3.org/WoT/IG/wiki/Marketing_WebConf
+ #Agendas
+STATUS:TENTATIVE
+CREATED:20230207T130336Z
+LAST-MODIFIED:20230207T130337Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:Teams
+RECURRENCE-ID;TZID=America/New_York:20230228T073000
+END:VEVENT
+BEGIN:VEVENT
+UID:45cf6f40-47f5-42bc-92f9-62196c437568
+DTSTAMP:20230502T115449Z
+SUMMARY:CANCELLED WoT Marketing
+DTSTART;TZID=America/New_York:20230502T073000
+DTEND;TZID=America/New_York:20230502T080000
+DESCRIPTION:https://www.w3.org/events/meetings/45cf6f40-47f5-42bc-92f9-6219
+ 6c437568/20230502T073000\n\nThe [WoT Marketing task force](https://www.w3.
+ org/WoT/IG/wiki/Marketing_WebConf) is responsible for reaching out and col
+ laborating with the community to increase the adoption of the WoT. The Mar
+ keting Task Force works on promoting the W3C Web of Things in different wa
+ ys such as Web presence\, Social Media presence\, and more.\n\n[IRC: #wot-
+ marketing](https://irc.w3.org/?channels=wot-marketing) / [WebEx](https://l
+ ists.w3.org/Archives/Member/member-wot-wg/2020Aug/0024.html)\n\nAgenda: ht
+ tps://www.w3.org/WoT/IG/wiki/Marketing_WebConf#Agendas
+STATUS:TENTATIVE
+CREATED:20230411T104428Z
+LAST-MODIFIED:20230502T115449Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:Webex
+RECURRENCE-ID;TZID=America/New_York:20230502T073000
+END:VEVENT
+BEGIN:VEVENT
+UID:bf5f8407-1b4e-4931-b149-e7d71f85a938
+DTSTAMP:20230529T105126Z
+SUMMARY:WoT Marketing
+DTSTART;TZID=America/New_York:20230530T073000
+DTEND;TZID=America/New_York:20230530T080000
+DESCRIPTION:https://www.w3.org/events/meetings/bf5f8407-1b4e-4931-b149-e7d7
+ 1f85a938\n\nNow with the Microsoft Teams link. Testing for one week and th
+ en changing the rest.\n\nThe [WoT Marketing task force](https://www.w3.org
+ /WoT/IG/wiki/Marketing_WebConf) is responsible for reaching out and collab
+ orating with the community to increase the adoption of the WoT. The Market
+ ing Task Force works on promoting the W3C Web of Things in different ways 
+ such as Web presence\, Social Media presence\, and more.\n\nAgenda: https:
+ //www.w3.org/WoT/IG/wiki/Marketing_WebConf#Agendas
+STATUS:CONFIRMED
+CREATED:20230529T104710Z
+LAST-MODIFIED:20230529T105126Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:Teams
+RELATED-TO:45cf6f40-47f5-42bc-92f9-62196c437568
+RRULE:FREQ=WEEKLY;UNTIL=20231231T123000Z;INTERVAL=1;BYDAY=TU;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:bf5f8407-1b4e-4931-b149-e7d71f85a938
+DTSTAMP:20230529T105126Z
+SUMMARY:WoT Marketing
+DTSTART;TZID=America/New_York:20230606T073000
+DTEND;TZID=America/New_York:20230606T080000
+DESCRIPTION:https://www.w3.org/events/meetings/bf5f8407-1b4e-4931-b149-e7d7
+ 1f85a938/20230606T073000\n\nThe [WoT Marketing task force](https://www.w3.
+ org/WoT/IG/wiki/Marketing_WebConf) is responsible for reaching out and col
+ laborating with the community to increase the adoption of the WoT. The Mar
+ keting Task Force works on promoting the W3C Web of Things in different wa
+ ys such as Web presence\, Social Media presence\, and more.\n\n[IRC: #wot-
+ marketing](https://irc.w3.org/?channels=wot-marketing) / [WebEx](https://l
+ ists.w3.org/Archives/Member/member-wot-wg/2020Aug/0024.html)\n\nAgenda: ht
+ tps://www.w3.org/WoT/IG/wiki/Marketing_WebConf#Agendas
+STATUS:CONFIRMED
+CREATED:20230411T104440Z
+LAST-MODIFIED:20230529T105126Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:Webex
+RECURRENCE-ID;TZID=America/New_York:20230606T073000
+END:VEVENT
+BEGIN:VEVENT
+UID:d1c9ad2e-7a17-4954-b2b0-6dcc30387821
+DTSTAMP:20220511T100222Z
+SUMMARY:WoT Use Cases
+DTSTART;TZID=America/New_York:20220308T080000
+DTEND;TZID=America/New_York:20220308T090000
+DESCRIPTION:https://www.w3.org/events/meetings/d1c9ad2e-7a17-4954-b2b0-6dcc
+ 30387821\n\nThe [WoT Use Case task force](https://www.w3.org/WoT/IG/wiki/I
+ G_UseCase_WebConf) is responsible for collecting use cases for WoT and ext
+ racting requirements. Use cases can include both specific vertical applica
+ tions as well as relevant horizontal technologies or other horizontal usag
+ e patterns. Guests who are not WoT members but who have an interest in spe
+ cific vertical application domains\, technologies\, or usage patterns are 
+ explicitly invited to engage with this task force to provide input.\n\n[IR
+ C: #wot-uc](https://irc.w3.org/?channels=wot-uc) / [WebEx](https://lists.w
+ 3.org/Archives/Member/member-wot-wg/2021Mar/0044.html)
+STATUS:CONFIRMED
+CREATED:20220301T202821Z
+LAST-MODIFIED:20220511T100222Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RRULE:FREQ=WEEKLY;UNTIL=20220503T120000Z;INTERVAL=2;BYDAY=TU;WKST=MO
+RELATED-TO:d8822b14-44c4-4b87-a168-d3ab7ba9199e
+END:VEVENT
+BEGIN:VEVENT
+UID:d1c9ad2e-7a17-4954-b2b0-6dcc30387821
+DTSTAMP:20220413T100923Z
+SUMMARY:WoT Use Cases
+DTSTART;TZID=America/New_York:20220419T080000
+DTEND;TZID=America/New_York:20220419T090000
+DESCRIPTION:https://www.w3.org/events/meetings/d1c9ad2e-7a17-4954-b2b0-6dcc
+ 30387821/20220419T080000\n\nThe [WoT Use Case task force](https://www.w3.o
+ rg/WoT/IG/wiki/IG_UseCase_WebConf) is responsible for collecting use cases
+  for WoT and extracting requirements. Use cases can include both specific 
+ vertical applications as well as relevant horizontal technologies or other
+  horizontal usage patterns. Guests who are not WoT members but who have an
+  interest in specific vertical application domains\, technologies\, or usa
+ ge patterns are explicitly invited to engage with this task force to provi
+ de input.\n\n[IRC: #wot-uc](https://irc.w3.org/?channels=wot-uc) / [WebEx]
+ (https://lists.w3.org/Archives/Member/member-wot-wg/2021Mar/0044.html)
+STATUS:CANCELLED
+CREATED:20220413T100921Z
+LAST-MODIFIED:20220413T100923Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220419T080000
+END:VEVENT
+BEGIN:VEVENT
+UID:d8822b14-44c4-4b87-a168-d3ab7ba9199e
+DTSTAMP:20220511T123210Z
+SUMMARY:WoT Use Cases
+DTSTART;TZID=America/New_York:20220517T080000
+DTEND;TZID=America/New_York:20220517T090000
+DESCRIPTION:https://www.w3.org/events/meetings/d8822b14-44c4-4b87-a168-d3ab
+ 7ba9199e\n\nThe [WoT Use Case task force](https://www.w3.org/WoT/IG/wiki/I
+ G_UseCase_WebConf) is responsible for collecting use cases for WoT and ext
+ racting requirements. Use cases can include both specific vertical applica
+ tions as well as relevant horizontal technologies or other horizontal usag
+ e patterns. Guests who are not WoT members but who have an interest in spe
+ cific vertical application domains\, technologies\, or usage patterns are 
+ explicitly invited to engage with this task force to provide input.\n\n[IR
+ C: #wot-uc](https://irc.w3.org/?channels=wot-uc) / [WebEx](https://lists.w
+ 3.org/Archives/Member/member-wot-wg/2021Mar/0044.html)
+STATUS:CANCELLED
+CREATED:20220511T100220Z
+LAST-MODIFIED:20220511T123210Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RELATED-TO:d1c9ad2e-7a17-4954-b2b0-6dcc30387821
+RRULE:FREQ=WEEKLY;UNTIL=20230201T130000Z;INTERVAL=2;BYDAY=TU;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:1420a6d9-efd4-4606-bef0-81b0af9ba17b
+DTSTAMP:20220307T163926Z
+SUMMARY:WoT Profiles
+DTSTART;TZID=America/New_York:20220302T070000
+DTEND;TZID=America/New_York:20220302T080000
+DESCRIPTION:https://www.w3.org/events/meetings/1420a6d9-efd4-4606-bef0-81b0
+ af9ba17b\n\nThe [WoT Architecture task force](https://www.w3.org/WoT/IG/wi
+ ki/WG_WoT_Architecture_WebConf) is responsible for both the abstract archi
+ tecture and interoperability profiles for the Web of Things.\n\n[IRC: #wot
+ -profile](https://irc.w3.org/#channels=wot-profile) / [WebEx](https://list
+ s.w3.org/Archives/Member/member-wot-wg/2022Jan/0006.html)
+STATUS:CONFIRMED
+CREATED:20220301T203224Z
+LAST-MODIFIED:20220307T163926Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RRULE:FREQ=WEEKLY;UNTIL=20220302T120000Z;INTERVAL=1;BYDAY=WE;WKST=MO
+RELATED-TO:21b6bd45-06fa-479d-abce-58b656982278
+END:VEVENT
+BEGIN:VEVENT
+UID:21b6bd45-06fa-479d-abce-58b656982278
+DTSTAMP:20221019T125454Z
+SUMMARY:WoT Profiles
+DTSTART;TZID=America/New_York:20220309T070000
+DTEND;TZID=America/New_York:20220309T080000
+DESCRIPTION:https://www.w3.org/events/meetings/21b6bd45-06fa-479d-abce-58b6
+ 56982278\n\nThe [WoT Architecture task force](https://www.w3.org/WoT/IG/wi
+ ki/WG_WoT_Architecture_WebConf) is responsible for both the abstract archi
+ tecture and interoperability profiles for the Web of Things.\n\n[IRC: #wot
+ -profile](https://irc.w3.org/#channels=wot-profile) / [WebEx](https://list
+ s.w3.org/Archives/Member/member-wot-wg/2022Jan/0006.html)
+STATUS:CONFIRMED
+CREATED:20220307T163922Z
+LAST-MODIFIED:20221019T125454Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RELATED-TO:1420a6d9-efd4-4606-bef0-81b0af9ba17b
+RELATED-TO:3d6aa0cc-45de-46e7-b839-1666f7e33bbb
+RRULE:FREQ=WEEKLY;UNTIL=20221019T110000Z;INTERVAL=1;BYDAY=WE;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:21b6bd45-06fa-479d-abce-58b656982278
+DTSTAMP:20220309T152309Z
+SUMMARY:WoT Profiles
+DTSTART;TZID=America/New_York:20220316T070000
+DTEND;TZID=America/New_York:20220316T080000
+DESCRIPTION:https://www.w3.org/events/meetings/21b6bd45-06fa-479d-abce-58b6
+ 56982278/20220316T070000\n\nThe [WoT Architecture task force](https://www.
+ w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf) is responsible for both th
+ e abstract architecture and interoperability profiles for the Web of Thing
+ s.\n\n[IRC: #wot-profile](https://irc.w3.org/#channels=wot-profile) / [Web
+ Ex](https://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0006.html)
+STATUS:CANCELLED
+CREATED:20220309T152307Z
+LAST-MODIFIED:20220309T152309Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220316T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:21b6bd45-06fa-479d-abce-58b656982278
+DTSTAMP:20220413T100359Z
+SUMMARY:WoT Profiles
+DTSTART;TZID=America/New_York:20220413T070000
+DTEND;TZID=America/New_York:20220413T080000
+DESCRIPTION:https://www.w3.org/events/meetings/21b6bd45-06fa-479d-abce-58b6
+ 56982278/20220413T070000\n\nThe [WoT Architecture task force](https://www.
+ w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf) is responsible for both th
+ e abstract architecture and interoperability profiles for the Web of Thing
+ s.\n\n[IRC: #wot-profile](https://irc.w3.org/#channels=wot-profile) / [Web
+ Ex](https://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0006.html)
+STATUS:CANCELLED
+CREATED:20220413T100358Z
+LAST-MODIFIED:20220413T100359Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220413T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:21b6bd45-06fa-479d-abce-58b656982278
+DTSTAMP:20220413T100952Z
+SUMMARY:WoT Profiles
+DTSTART;TZID=America/New_York:20220420T070000
+DTEND;TZID=America/New_York:20220420T080000
+DESCRIPTION:https://www.w3.org/events/meetings/21b6bd45-06fa-479d-abce-58b6
+ 56982278/20220420T070000\n\nThe [WoT Architecture task force](https://www.
+ w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf) is responsible for both th
+ e abstract architecture and interoperability profiles for the Web of Thing
+ s.\n\n[IRC: #wot-profile](https://irc.w3.org/#channels=wot-profile) / [Web
+ Ex](https://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0006.html)
+STATUS:CANCELLED
+CREATED:20220413T100951Z
+LAST-MODIFIED:20220413T100952Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220420T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:21b6bd45-06fa-479d-abce-58b656982278
+DTSTAMP:20220601T100657Z
+SUMMARY:WoT Profiles
+DTSTART;TZID=America/New_York:20220601T070000
+DTEND;TZID=America/New_York:20220601T080000
+DESCRIPTION:https://www.w3.org/events/meetings/21b6bd45-06fa-479d-abce-58b6
+ 56982278/20220601T070000\n\nThe [WoT Architecture task force](https://www.
+ w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf) is responsible for both th
+ e abstract architecture and interoperability profiles for the Web of Thing
+ s.\n\n[IRC: #wot-profile](https://irc.w3.org/#channels=wot-profile) / [Web
+ Ex](https://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0006.html)
+STATUS:CANCELLED
+CREATED:20220601T100655Z
+LAST-MODIFIED:20220601T100657Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220601T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:21b6bd45-06fa-479d-abce-58b656982278
+DTSTAMP:20220608T102408Z
+SUMMARY:WoT Profiles
+DTSTART;TZID=America/New_York:20220608T070000
+DTEND;TZID=America/New_York:20220608T080000
+DESCRIPTION:https://www.w3.org/events/meetings/21b6bd45-06fa-479d-abce-58b6
+ 56982278/20220608T070000\n\nThe [WoT Architecture task force](https://www.
+ w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf) is responsible for both th
+ e abstract architecture and interoperability profiles for the Web of Thing
+ s.\n\n[IRC: #wot-profile](https://irc.w3.org/#channels=wot-profile) / [Web
+ Ex](https://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0006.html)
+STATUS:CANCELLED
+CREATED:20220608T102407Z
+LAST-MODIFIED:20220608T102408Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220608T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:21b6bd45-06fa-479d-abce-58b656982278
+DTSTAMP:20220706T105335Z
+SUMMARY:WoT Profiles
+DTSTART;TZID=America/New_York:20220309T070000
+DTEND;TZID=America/New_York:20220309T080000
+DESCRIPTION:https://www.w3.org/events/meetings/21b6bd45-06fa-479d-abce-58b6
+ 56982278/20220309T070000\n\nThe [WoT Architecture task force](https://www.
+ w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf) is responsible for both th
+ e abstract architecture and interoperability profiles for the Web of Thing
+ s.\n\n[IRC: #wot-profile](https://irc.w3.org/#channels=wot-profile) / [Web
+ Ex](https://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0006.html)
+STATUS:CANCELLED
+CREATED:20220706T105333Z
+LAST-MODIFIED:20220706T105335Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220309T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:21b6bd45-06fa-479d-abce-58b656982278
+DTSTAMP:20220725T120302Z
+SUMMARY:WoT Profiles
+DTSTART;TZID=America/New_York:20220727T070000
+DTEND;TZID=America/New_York:20220727T080000
+DESCRIPTION:https://www.w3.org/events/meetings/21b6bd45-06fa-479d-abce-58b6
+ 56982278/20220727T070000\n\nThe [WoT Architecture task force](https://www.
+ w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf) is responsible for both th
+ e abstract architecture and interoperability profiles for the Web of Thing
+ s.\n\n[IRC: #wot-profile](https://irc.w3.org/#channels=wot-profile) / [Web
+ Ex](https://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0006.html)
+STATUS:CANCELLED
+CREATED:20220725T120301Z
+LAST-MODIFIED:20220725T120302Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220727T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:21b6bd45-06fa-479d-abce-58b656982278
+DTSTAMP:20220830T132618Z
+SUMMARY:WoT Profiles
+DTSTART;TZID=America/New_York:20220831T070000
+DTEND;TZID=America/New_York:20220831T080000
+DESCRIPTION:https://www.w3.org/events/meetings/21b6bd45-06fa-479d-abce-58b6
+ 56982278/20220831T070000\n\n(note: UNCANCELED\, but status of a canceled e
+ vent cannot be changed\; see the new entry)\n\nThe [WoT Architecture task 
+ force](https://www.w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf) is resp
+ onsible for both the abstract architecture and interoperability profiles f
+ or the Web of Things.\n\n[IRC: #wot-profile](https://irc.w3.org/#channels=
+ wot-profile) / [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/
+ 2022Jan/0006.html)
+STATUS:CANCELLED
+CREATED:20220823T131246Z
+LAST-MODIFIED:20220830T132618Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220831T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:21b6bd45-06fa-479d-abce-58b656982278
+DTSTAMP:20220831T162031Z
+SUMMARY:WoT Profiles
+DTSTART;TZID=America/New_York:20220914T070000
+DTEND;TZID=America/New_York:20220914T080000
+DESCRIPTION:https://www.w3.org/events/meetings/21b6bd45-06fa-479d-abce-58b6
+ 56982278/20220914T070000\n\nThe [WoT Architecture task force](https://www.
+ w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf) is responsible for both th
+ e abstract architecture and interoperability profiles for the Web of Thing
+ s.\n\n[IRC: #wot-profile](https://irc.w3.org/#channels=wot-profile) / [Web
+ Ex](https://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0006.html)
+STATUS:CANCELLED
+CREATED:20220831T162030Z
+LAST-MODIFIED:20220831T162031Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220914T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:21b6bd45-06fa-479d-abce-58b656982278
+DTSTAMP:20221003T112405Z
+SUMMARY:WoT Profiles
+DTSTART;TZID=America/New_York:20221005T070000
+DTEND;TZID=America/New_York:20221005T080000
+DESCRIPTION:https://www.w3.org/events/meetings/21b6bd45-06fa-479d-abce-58b6
+ 56982278/20221005T070000\n\nThe [WoT Architecture task force](https://www.
+ w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf) is responsible for both th
+ e abstract architecture and interoperability profiles for the Web of Thing
+ s.\n\n[IRC: #wot-profile](https://irc.w3.org/#channels=wot-profile) / [Web
+ Ex](https://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0006.html)
+STATUS:CANCELLED
+CREATED:20221003T112404Z
+LAST-MODIFIED:20221003T112405Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20221005T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:3d6aa0cc-45de-46e7-b839-1666f7e33bbb
+DTSTAMP:20230201T170437Z
+SUMMARY:WoT Profiles
+DTSTART;TZID=America/New_York:20221026T070000
+DTEND;TZID=America/New_York:20221026T080000
+DESCRIPTION:https://www.w3.org/events/meetings/3d6aa0cc-45de-46e7-b839-1666
+ f7e33bbb\n\nThe [WoT Architecture task force](https://www.w3.org/WoT/IG/wi
+ ki/WG_WoT_Architecture_WebConf) is responsible for both the abstract archi
+ tecture and interoperability profiles for the Web of Things.\n\n[IRC: #wot
+ -profile](https://irc.w3.org/#channels=wot-profile) / [WebEx](https://list
+ s.w3.org/Archives/Member/member-wot-wg/2022Jan/0006.html)
+STATUS:CONFIRMED
+CREATED:20221019T125454Z
+LAST-MODIFIED:20230201T170437Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RELATED-TO:21b6bd45-06fa-479d-abce-58b656982278
+RELATED-TO:dc28662c-232b-4962-bc6e-e7756d739608
+RRULE:FREQ=WEEKLY;UNTIL=20230125T120000Z;INTERVAL=1;BYDAY=WE;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:3d6aa0cc-45de-46e7-b839-1666f7e33bbb
+DTSTAMP:20221207T165801Z
+SUMMARY:WoT Profiles
+DTSTART;TZID=America/New_York:20221214T070000
+DTEND;TZID=America/New_York:20221214T080000
+DESCRIPTION:https://www.w3.org/events/meetings/3d6aa0cc-45de-46e7-b839-1666
+ f7e33bbb/20221214T070000\n\nThe [WoT Architecture task force](https://www.
+ w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf) is responsible for both th
+ e abstract architecture and interoperability profiles for the Web of Thing
+ s.\n\n[IRC: #wot-profile](https://irc.w3.org/#channels=wot-profile) / [Web
+ Ex](https://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0006.html)
+STATUS:CANCELLED
+CREATED:20221207T165800Z
+LAST-MODIFIED:20221207T165801Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20221214T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:3d6aa0cc-45de-46e7-b839-1666f7e33bbb
+DTSTAMP:20230111T112222Z
+SUMMARY:WoT Profiles
+DTSTART;TZID=America/New_York:20230118T070000
+DTEND;TZID=America/New_York:20230118T080000
+DESCRIPTION:https://www.w3.org/events/meetings/3d6aa0cc-45de-46e7-b839-1666
+ f7e33bbb/20230118T070000\n\nThe [WoT Architecture task force](https://www.
+ w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf) is responsible for both th
+ e abstract architecture and interoperability profiles for the Web of Thing
+ s.\n\n[IRC: #wot-profile](https://irc.w3.org/#channels=wot-profile) / [Web
+ Ex](https://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0006.html)
+STATUS:CANCELLED
+CREATED:20230111T112221Z
+LAST-MODIFIED:20230111T112222Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20230118T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:3d6aa0cc-45de-46e7-b839-1666f7e33bbb
+DTSTAMP:20230125T115957Z
+SUMMARY:WoT Profiles
+DTSTART;TZID=America/New_York:20230125T070000
+DTEND;TZID=America/New_York:20230125T080000
+DESCRIPTION:https://www.w3.org/events/meetings/3d6aa0cc-45de-46e7-b839-1666
+ f7e33bbb/20230125T070000\n\nThe [WoT Architecture task force](https://www.
+ w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf) is responsible for both th
+ e abstract architecture and interoperability profiles for the Web of Thing
+ s.\n\n[IRC: #wot-profile](https://irc.w3.org/#channels=wot-profile) / [Web
+ Ex](https://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0006.html)
+STATUS:CANCELLED
+CREATED:20230125T115956Z
+LAST-MODIFIED:20230125T115957Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20230125T070000
+END:VEVENT
+BEGIN:VEVENT
+UID:dc28662c-232b-4962-bc6e-e7756d739608
+DTSTAMP:20230530T121807Z
+SUMMARY:WoT Profiles
+DTSTART;TZID=America/New_York:20230201T070000
+DTEND;TZID=America/New_York:20230201T080000
+DESCRIPTION:https://www.w3.org/events/meetings/dc28662c-232b-4962-bc6e-e775
+ 6d739608\n\nThe [WoT Architecture task force](https://www.w3.org/WoT/IG/wi
+ ki/WG_WoT_Architecture_WebConf) is responsible for both the abstract archi
+ tecture and interoperability profiles for the Web of Things.\n\n[IRC: #wot
+ -profile](https://irc.w3.org/#channels=wot-profile) / [WebEx](https://list
+ s.w3.org/Archives/Member/member-wot-wg/2022Jan/0006.html)
+STATUS:CONFIRMED
+CREATED:20230201T170435Z
+LAST-MODIFIED:20230530T121807Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RELATED-TO:3d6aa0cc-45de-46e7-b839-1666f7e33bbb
+RELATED-TO:ad5b80fa-d2a9-467e-a06d-cfac22b77a70
+RRULE:FREQ=WEEKLY;UNTIL=20230524T110000Z;INTERVAL=1;BYDAY=WE;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:ad5b80fa-d2a9-467e-a06d-cfac22b77a70
+DTSTAMP:20230530T121850Z
+SUMMARY:WoT Profiles - TEMPORARILY SUSPENDED
+DTSTART;TZID=America/New_York:20230531T070000
+DTEND;TZID=America/New_York:20230531T080000
+DESCRIPTION:https://www.w3.org/events/meetings/ad5b80fa-d2a9-467e-a06d-cfac
+ 22b77a70\n\nTEMPORARILY SUSPENDED - until new charter starts\n\nThe [WoT P
+ rofile task force](https://www.w3.org/WoT/IG/wiki/WG_WoT_Profile_WebConf) 
+ is responsible for the interoperability profiles for the Web of Things.\n\
+ n[IRC: #wot-profile](https://irc.w3.org/#channels=wot-profile) / [WebEx](h
+ ttps://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0006.html)
+STATUS:CONFIRMED
+CREATED:20230530T121807Z
+LAST-MODIFIED:20230530T121850Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:Zoom TBD
+RELATED-TO:dc28662c-232b-4962-bc6e-e7756d739608
+RRULE:FREQ=WEEKLY;UNTIL=20230801T110000Z;INTERVAL=1;BYDAY=WE;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:926e73bd-0bbb-4dc1-bd53-4f9e6543bc12
+DTSTAMP:20220307T165053Z
+SUMMARY:WoT TD/Binding Templates
+DTSTART;TZID=America/New_York:20220302T100000
+DTEND;TZID=America/New_York:20220302T120000
+DESCRIPTION:https://www.w3.org/events/meetings/926e73bd-0bbb-4dc1-bd53-4f9e
+ 6543bc12\n\nThe [WoT Thing Description task force](https://www.w3.org/WoT/
+ IG/wiki/WG_WoT_Thing_Description_WebConf) is responsible for defining the 
+ information model for WoT Thing metadata\, its interpretation\, and its co
+ mmon representation. In addition\, the task force covers WoT Binding Templ
+ ates topics to define the mapping from the abstract interaction model used
+  in the Thing Description metadata to concrete IoT protocols and payload e
+ ncodings.\n\n[IRC: #wot-td](https://irc.w3.org/?channels=wot-td) / [WebEx]
+ (https://lists.w3.org/Archives/Member/member-wot-wg/2020Jul/0027.html)
+STATUS:CONFIRMED
+CREATED:20220301T203620Z
+LAST-MODIFIED:20220307T165053Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RRULE:FREQ=WEEKLY;UNTIL=20220302T150000Z;INTERVAL=1;BYDAY=WE;WKST=MO
+RELATED-TO:97fe8500-0d73-4762-92a3-2376ba13999e
+END:VEVENT
+BEGIN:VEVENT
+UID:97fe8500-0d73-4762-92a3-2376ba13999e
+DTSTAMP:20221003T110652Z
+SUMMARY:WoT TD/Binding Templates
+DTSTART;TZID=America/New_York:20220309T100000
+DTEND;TZID=America/New_York:20220309T120000
+DESCRIPTION:https://www.w3.org/events/meetings/97fe8500-0d73-4762-92a3-2376
+ ba13999e\n\nThe [WoT Thing Description task force](https://www.w3.org/WoT/
+ IG/wiki/WG_WoT_Thing_Description_WebConf) is responsible for defining the 
+ information model for WoT Thing metadata\, its interpretation\, and its co
+ mmon representation. In addition\, the task force covers WoT Binding Templ
+ ates topics to define the mapping from the abstract interaction model used
+  in the Thing Description metadata to concrete IoT protocols and payload e
+ ncodings.\n\n[IRC: #wot-td](https://irc.w3.org/?channels=wot-td) / [WebEx]
+ (https://lists.w3.org/Archives/Member/member-wot-wg/2020Jul/0027.html)
+STATUS:CONFIRMED
+CREATED:20220307T165050Z
+LAST-MODIFIED:20221003T110652Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RELATED-TO:926e73bd-0bbb-4dc1-bd53-4f9e6543bc12
+RELATED-TO:193aa53c-e331-496b-9557-df0f7fe62b5c
+RRULE:FREQ=WEEKLY;UNTIL=20220928T140000Z;INTERVAL=1;BYDAY=WE;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:97fe8500-0d73-4762-92a3-2376ba13999e
+DTSTAMP:20220309T152756Z
+SUMMARY:WoT TD/Binding Templates
+DTSTART;TZID=America/New_York:20220316T100000
+DTEND;TZID=America/New_York:20220316T120000
+DESCRIPTION:https://www.w3.org/events/meetings/97fe8500-0d73-4762-92a3-2376
+ ba13999e/20220316T100000\n\nThe [WoT Thing Description task force](https:/
+ /www.w3.org/WoT/IG/wiki/WG_WoT_Thing_Description_WebConf) is responsible f
+ or defining the information model for WoT Thing metadata\, its interpretat
+ ion\, and its common representation. In addition\, the task force covers W
+ oT Binding Templates topics to define the mapping from the abstract intera
+ ction model used in the Thing Description metadata to concrete IoT protoco
+ ls and payload encodings.\n\n[IRC: #wot-td](https://irc.w3.org/?channels=w
+ ot-td) / [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2020Ju
+ l/0027.html)
+STATUS:CANCELLED
+CREATED:20220309T152754Z
+LAST-MODIFIED:20220309T152756Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220316T100000
+END:VEVENT
+BEGIN:VEVENT
+UID:97fe8500-0d73-4762-92a3-2376ba13999e
+DTSTAMP:20220309T153214Z
+SUMMARY:WoT TD/Binding Templates/AB
+DTSTART;TZID=America/New_York:20220323T100000
+DTEND;TZID=America/New_York:20220323T120000
+DESCRIPTION:https://www.w3.org/events/meetings/97fe8500-0d73-4762-92a3-2376
+ ba13999e/20220323T100000\n\nException: the second hour of this call will b
+ e used for a presentation from members of the AB.\n\nThe [WoT Thing Descri
+ ption task force](https://www.w3.org/WoT/IG/wiki/WG_WoT_Thing_Description_
+ WebConf) is responsible for defining the information model for WoT Thing m
+ etadata\, its interpretation\, and its common representation. In addition\
+ , the task force covers WoT Binding Templates topics to define the mapping
+  from the abstract interaction model used in the Thing Description metadat
+ a to concrete IoT protocols and payload encodings.\n\n[IRC: #wot-td](https
+ ://irc.w3.org/?channels=wot-td) / [WebEx](https://lists.w3.org/Archives/Me
+ mber/member-wot-wg/2020Jul/0027.html)
+STATUS:CONFIRMED
+CREATED:20220309T153212Z
+LAST-MODIFIED:20220309T153214Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220323T100000
+END:VEVENT
+BEGIN:VEVENT
+UID:97fe8500-0d73-4762-92a3-2376ba13999e
+DTSTAMP:20220525T160204Z
+SUMMARY:WoT TD/Binding Templates
+DTSTART;TZID=America/New_York:20220601T100000
+DTEND;TZID=America/New_York:20220601T120000
+DESCRIPTION:https://www.w3.org/events/meetings/97fe8500-0d73-4762-92a3-2376
+ ba13999e/20220601T100000\n\nThe [WoT Thing Description task force](https:/
+ /www.w3.org/WoT/IG/wiki/WG_WoT_Thing_Description_WebConf) is responsible f
+ or defining the information model for WoT Thing metadata\, its interpretat
+ ion\, and its common representation. In addition\, the task force covers W
+ oT Binding Templates topics to define the mapping from the abstract intera
+ ction model used in the Thing Description metadata to concrete IoT protoco
+ ls and payload encodings.\n\n[IRC: #wot-td](https://irc.w3.org/?channels=w
+ ot-td) / [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2020Ju
+ l/0027.html)
+STATUS:CANCELLED
+CREATED:20220525T160202Z
+LAST-MODIFIED:20220525T160204Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220601T100000
+END:VEVENT
+BEGIN:VEVENT
+UID:97fe8500-0d73-4762-92a3-2376ba13999e
+DTSTAMP:20220608T131306Z
+SUMMARY:WoT TD/Binding Templates
+DTSTART;TZID=America/New_York:20220608T100000
+DTEND;TZID=America/New_York:20220608T120000
+DESCRIPTION:https://www.w3.org/events/meetings/97fe8500-0d73-4762-92a3-2376
+ ba13999e/20220608T100000\n\nThe [WoT Thing Description task force](https:/
+ /www.w3.org/WoT/IG/wiki/WG_WoT_Thing_Description_WebConf) is responsible f
+ or defining the information model for WoT Thing metadata\, its interpretat
+ ion\, and its common representation. In addition\, the task force covers W
+ oT Binding Templates topics to define the mapping from the abstract intera
+ ction model used in the Thing Description metadata to concrete IoT protoco
+ ls and payload encodings.\n\n[IRC: #wot-td](https://irc.w3.org/?channels=w
+ ot-td) / [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2020Ju
+ l/0027.html)
+STATUS:CANCELLED
+CREATED:20220608T131305Z
+LAST-MODIFIED:20220608T131306Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220608T100000
+END:VEVENT
+BEGIN:VEVENT
+UID:97fe8500-0d73-4762-92a3-2376ba13999e
+DTSTAMP:20220720T144143Z
+SUMMARY:WoT TD/Binding Templates
+DTSTART;TZID=America/New_York:20220727T100000
+DTEND;TZID=America/New_York:20220727T120000
+DESCRIPTION:https://www.w3.org/events/meetings/97fe8500-0d73-4762-92a3-2376
+ ba13999e/20220727T100000\n\nThe [WoT Thing Description task force](https:/
+ /www.w3.org/WoT/IG/wiki/WG_WoT_Thing_Description_WebConf) is responsible f
+ or defining the information model for WoT Thing metadata\, its interpretat
+ ion\, and its common representation. In addition\, the task force covers W
+ oT Binding Templates topics to define the mapping from the abstract intera
+ ction model used in the Thing Description metadata to concrete IoT protoco
+ ls and payload encodings.\n\n[IRC: #wot-td](https://irc.w3.org/?channels=w
+ ot-td) / [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2020Ju
+ l/0027.html)
+STATUS:CANCELLED
+CREATED:20220720T144142Z
+LAST-MODIFIED:20220720T144143Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220727T100000
+END:VEVENT
+BEGIN:VEVENT
+UID:97fe8500-0d73-4762-92a3-2376ba13999e
+DTSTAMP:20220817T122228Z
+SUMMARY:WoT TD/Binding Templates
+DTSTART;TZID=America/New_York:20220824T100000
+DTEND;TZID=America/New_York:20220824T120000
+DESCRIPTION:https://www.w3.org/events/meetings/97fe8500-0d73-4762-92a3-2376
+ ba13999e/20220824T100000\n\nThe [WoT Thing Description task force](https:/
+ /www.w3.org/WoT/IG/wiki/WG_WoT_Thing_Description_WebConf) is responsible f
+ or defining the information model for WoT Thing metadata\, its interpretat
+ ion\, and its common representation. In addition\, the task force covers W
+ oT Binding Templates topics to define the mapping from the abstract intera
+ ction model used in the Thing Description metadata to concrete IoT protoco
+ ls and payload encodings.\n\n[IRC: #wot-td](https://irc.w3.org/?channels=w
+ ot-td) / [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2020Ju
+ l/0027.html)
+STATUS:CANCELLED
+CREATED:20220817T122227Z
+LAST-MODIFIED:20220817T122228Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220824T100000
+END:VEVENT
+BEGIN:VEVENT
+UID:97fe8500-0d73-4762-92a3-2376ba13999e
+DTSTAMP:20220817T122253Z
+SUMMARY:WoT TD/Binding Templates
+DTSTART;TZID=America/New_York:20220831T100000
+DTEND;TZID=America/New_York:20220831T120000
+DESCRIPTION:https://www.w3.org/events/meetings/97fe8500-0d73-4762-92a3-2376
+ ba13999e/20220831T100000\n\nThe [WoT Thing Description task force](https:/
+ /www.w3.org/WoT/IG/wiki/WG_WoT_Thing_Description_WebConf) is responsible f
+ or defining the information model for WoT Thing metadata\, its interpretat
+ ion\, and its common representation. In addition\, the task force covers W
+ oT Binding Templates topics to define the mapping from the abstract intera
+ ction model used in the Thing Description metadata to concrete IoT protoco
+ ls and payload encodings.\n\n[IRC: #wot-td](https://irc.w3.org/?channels=w
+ ot-td) / [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2020Ju
+ l/0027.html)
+STATUS:CANCELLED
+CREATED:20220817T122251Z
+LAST-MODIFIED:20220817T122253Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220831T100000
+END:VEVENT
+BEGIN:VEVENT
+UID:97fe8500-0d73-4762-92a3-2376ba13999e
+DTSTAMP:20220831T162234Z
+SUMMARY:WoT TD/Binding Templates
+DTSTART;TZID=America/New_York:20220914T100000
+DTEND;TZID=America/New_York:20220914T120000
+DESCRIPTION:https://www.w3.org/events/meetings/97fe8500-0d73-4762-92a3-2376
+ ba13999e/20220914T100000\n\nThe [WoT Thing Description task force](https:/
+ /www.w3.org/WoT/IG/wiki/WG_WoT_Thing_Description_WebConf) is responsible f
+ or defining the information model for WoT Thing metadata\, its interpretat
+ ion\, and its common representation. In addition\, the task force covers W
+ oT Binding Templates topics to define the mapping from the abstract intera
+ ction model used in the Thing Description metadata to concrete IoT protoco
+ ls and payload encodings.\n\n[IRC: #wot-td](https://irc.w3.org/?channels=w
+ ot-td) / [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2020Ju
+ l/0027.html)
+STATUS:CANCELLED
+CREATED:20220831T162233Z
+LAST-MODIFIED:20220831T162234Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220914T100000
+END:VEVENT
+BEGIN:VEVENT
+UID:97fe8500-0d73-4762-92a3-2376ba13999e
+DTSTAMP:20220916T131931Z
+SUMMARY:WoT TD/Binding Templates
+DTSTART;TZID=America/New_York:20220921T100000
+DTEND;TZID=America/New_York:20220921T120000
+DESCRIPTION:https://www.w3.org/events/meetings/97fe8500-0d73-4762-92a3-2376
+ ba13999e/20220921T100000\n\nThe [WoT Thing Description task force](https:/
+ /www.w3.org/WoT/IG/wiki/WG_WoT_Thing_Description_WebConf) is responsible f
+ or defining the information model for WoT Thing metadata\, its interpretat
+ ion\, and its common representation. In addition\, the task force covers W
+ oT Binding Templates topics to define the mapping from the abstract intera
+ ction model used in the Thing Description metadata to concrete IoT protoco
+ ls and payload encodings.\n\n[IRC: #wot-td](https://irc.w3.org/?channels=w
+ ot-td) / [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2020Ju
+ l/0027.html)
+STATUS:CANCELLED
+CREATED:20220916T131930Z
+LAST-MODIFIED:20220916T131931Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220921T100000
+END:VEVENT
+BEGIN:VEVENT
+UID:193aa53c-e331-496b-9557-df0f7fe62b5c
+DTSTAMP:20230201T150727Z
+SUMMARY:WoT TD/Binding Templates
+DTSTART;TZID=America/New_York:20221005T100000
+DTEND;TZID=America/New_York:20221005T120000
+DESCRIPTION:https://www.w3.org/events/meetings/193aa53c-e331-496b-9557-df0f
+ 7fe62b5c\n\nThe [WoT Thing Description task force](https://www.w3.org/WoT/
+ IG/wiki/WG_WoT_Thing_Description_WebConf) is responsible for defining the 
+ information model for WoT Thing metadata\, its interpretation\, and its co
+ mmon representation. In addition\, the task force covers WoT Binding Templ
+ ates topics to define the mapping from the abstract interaction model used
+  in the Thing Description metadata to concrete IoT protocols and payload e
+ ncodings.\n\n[IRC: #wot-td](https://irc.w3.org/?channels=wot-td) / [WebEx]
+ (https://lists.w3.org/Archives/Member/member-wot-wg/2020Jul/0027.html)
+STATUS:CONFIRMED
+CREATED:20221003T110121Z
+LAST-MODIFIED:20230201T150727Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RELATED-TO:97fe8500-0d73-4762-92a3-2376ba13999e
+RELATED-TO:3f89692a-2708-45b6-bb12-b8f3e26ed35d
+RRULE:FREQ=WEEKLY;UNTIL=20230125T150000Z;INTERVAL=1;BYDAY=WE;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:193aa53c-e331-496b-9557-df0f7fe62b5c
+DTSTAMP:20221213T151957Z
+SUMMARY:WoT TD/Binding Templates
+DTSTART;TZID=America/New_York:20221214T100000
+DTEND;TZID=America/New_York:20221214T120000
+DESCRIPTION:https://www.w3.org/events/meetings/193aa53c-e331-496b-9557-df0f
+ 7fe62b5c/20221214T100000\n\nThe [WoT Thing Description task force](https:/
+ /www.w3.org/WoT/IG/wiki/WG_WoT_Thing_Description_WebConf) is responsible f
+ or defining the information model for WoT Thing metadata\, its interpretat
+ ion\, and its common representation. In addition\, the task force covers W
+ oT Binding Templates topics to define the mapping from the abstract intera
+ ction model used in the Thing Description metadata to concrete IoT protoco
+ ls and payload encodings.\n\n[IRC: #wot-td](https://irc.w3.org/?channels=w
+ ot-td) / [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2020Ju
+ l/0027.html)
+STATUS:CANCELLED
+CREATED:20221207T165852Z
+LAST-MODIFIED:20221213T151957Z
+SEQUENCE:4
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20221214T100000
+END:VEVENT
+BEGIN:VEVENT
+UID:193aa53c-e331-496b-9557-df0f7fe62b5c
+DTSTAMP:20230111T112342Z
+SUMMARY:WoT TD/Binding Templates
+DTSTART;TZID=America/New_York:20230118T100000
+DTEND;TZID=America/New_York:20230118T120000
+DESCRIPTION:https://www.w3.org/events/meetings/193aa53c-e331-496b-9557-df0f
+ 7fe62b5c/20230118T100000\n\nThe [WoT Thing Description task force](https:/
+ /www.w3.org/WoT/IG/wiki/WG_WoT_Thing_Description_WebConf) is responsible f
+ or defining the information model for WoT Thing metadata\, its interpretat
+ ion\, and its common representation. In addition\, the task force covers W
+ oT Binding Templates topics to define the mapping from the abstract intera
+ ction model used in the Thing Description metadata to concrete IoT protoco
+ ls and payload encodings.\n\n[IRC: #wot-td](https://irc.w3.org/?channels=w
+ ot-td) / [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2020Ju
+ l/0027.html)
+STATUS:CANCELLED
+CREATED:20230111T112341Z
+LAST-MODIFIED:20230111T112342Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20230118T100000
+END:VEVENT
+BEGIN:VEVENT
+UID:3f89692a-2708-45b6-bb12-b8f3e26ed35d
+DTSTAMP:20230529T112121Z
+SUMMARY:WoT TD/Binding Templates
+DTSTART;TZID=America/New_York:20230201T100000
+DTEND;TZID=America/New_York:20230201T120000
+DESCRIPTION:https://www.w3.org/events/meetings/3f89692a-2708-45b6-bb12-b8f3
+ e26ed35d\n\nThe [WoT Thing Description task force](https://www.w3.org/WoT/
+ IG/wiki/WG_WoT_Thing_Description_WebConf) is responsible for defining the 
+ information model for WoT Thing metadata\, its interpretation\, and its co
+ mmon representation. In addition\, the task force covers WoT Binding Templ
+ ates topics to define the mapping from the abstract interaction model used
+  in the Thing Description metadata to concrete IoT protocols and payload e
+ ncodings.\n\n[IRC: #wot-td](https://irc.w3.org/?channels=wot-td) / [WebEx]
+ (https://lists.w3.org/Archives/Member/member-wot-wg/2020Jul/0027.html)
+STATUS:CONFIRMED
+CREATED:20230201T150725Z
+LAST-MODIFIED:20230529T112121Z
+SEQUENCE:4
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RELATED-TO:193aa53c-e331-496b-9557-df0f7fe62b5c
+RELATED-TO:9c7cb2bb-f11b-46f2-8677-3a74edadcdbc
+RRULE:FREQ=WEEKLY;UNTIL=20230524T140000Z;INTERVAL=1;BYDAY=WE;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:3f89692a-2708-45b6-bb12-b8f3e26ed35d
+DTSTAMP:20230412T140048Z
+SUMMARY:CANCELLED - WoT TD/Binding Templates
+DTSTART;TZID=America/New_York:20230419T100000
+DTEND;TZID=America/New_York:20230419T120000
+DESCRIPTION:https://www.w3.org/events/meetings/3f89692a-2708-45b6-bb12-b8f3
+ e26ed35d/20230419T100000\n\nMeeting is cancelled but only marking tentativ
+ e to be able to revert it if needed\n\n\nThe [WoT Thing Description task f
+ orce](https://www.w3.org/WoT/IG/wiki/WG_WoT_Thing_Description_WebConf) is 
+ responsible for defining the information model for WoT Thing metadata\, it
+ s interpretation\, and its common representation. In addition\, the task f
+ orce covers WoT Binding Templates topics to define the mapping from the ab
+ stract interaction model used in the Thing Description metadata to concret
+ e IoT protocols and payload encodings.\n\n[IRC: #wot-td](https://irc.w3.or
+ g/?channels=wot-td) / [WebEx](https://lists.w3.org/Archives/Member/member-
+ wot-wg/2020Jul/0027.html)
+STATUS:TENTATIVE
+CREATED:20230412T140047Z
+LAST-MODIFIED:20230412T140048Z
+SEQUENCE:4
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20230419T100000
+END:VEVENT
+BEGIN:VEVENT
+UID:3f89692a-2708-45b6-bb12-b8f3e26ed35d
+DTSTAMP:20230502T120724Z
+SUMMARY:CANCELLED WoT TD/Binding Templates
+DTSTART;TZID=America/New_York:20230503T100000
+DTEND;TZID=America/New_York:20230503T120000
+DESCRIPTION:https://www.w3.org/events/meetings/3f89692a-2708-45b6-bb12-b8f3
+ e26ed35d/20230503T100000\n\nThe [WoT Thing Description task force](https:/
+ /www.w3.org/WoT/IG/wiki/WG_WoT_Thing_Description_WebConf) is responsible f
+ or defining the information model for WoT Thing metadata\, its interpretat
+ ion\, and its common representation. In addition\, the task force covers W
+ oT Binding Templates topics to define the mapping from the abstract intera
+ ction model used in the Thing Description metadata to concrete IoT protoco
+ ls and payload encodings.\n\n[IRC: #wot-td](https://irc.w3.org/?channels=w
+ ot-td) / [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2020Ju
+ l/0027.html)
+STATUS:TENTATIVE
+CREATED:20230502T120723Z
+LAST-MODIFIED:20230502T120724Z
+SEQUENCE:4
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20230503T100000
+END:VEVENT
+BEGIN:VEVENT
+UID:3f89692a-2708-45b6-bb12-b8f3e26ed35d
+DTSTAMP:20230502T120757Z
+SUMMARY:CANCELLED WoT TD/Binding Templates
+DTSTART;TZID=America/New_York:20230510T100000
+DTEND;TZID=America/New_York:20230510T120000
+DESCRIPTION:https://www.w3.org/events/meetings/3f89692a-2708-45b6-bb12-b8f3
+ e26ed35d/20230510T100000\n\nThe [WoT Thing Description task force](https:/
+ /www.w3.org/WoT/IG/wiki/WG_WoT_Thing_Description_WebConf) is responsible f
+ or defining the information model for WoT Thing metadata\, its interpretat
+ ion\, and its common representation. In addition\, the task force covers W
+ oT Binding Templates topics to define the mapping from the abstract intera
+ ction model used in the Thing Description metadata to concrete IoT protoco
+ ls and payload encodings.\n\n[IRC: #wot-td](https://irc.w3.org/?channels=w
+ ot-td) / [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2020Ju
+ l/0027.html)
+STATUS:TENTATIVE
+CREATED:20230502T120755Z
+LAST-MODIFIED:20230502T120757Z
+SEQUENCE:4
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20230510T100000
+END:VEVENT
+BEGIN:VEVENT
+UID:9c7cb2bb-f11b-46f2-8677-3a74edadcdbc
+DTSTAMP:20230529T112220Z
+SUMMARY:WoT TD/Binding Templates
+DTSTART;TZID=America/New_York:20230531T100000
+DTEND;TZID=America/New_York:20230531T120000
+DESCRIPTION:https://www.w3.org/events/meetings/9c7cb2bb-f11b-46f2-8677-3a74
+ edadcdbc\n\nThe [WoT Thing Description task force](https://www.w3.org/WoT/
+ IG/wiki/WG_WoT_Thing_Description_WebConf) is responsible for defining the 
+ information model for WoT Thing metadata\, its interpretation\, and its co
+ mmon representation. In addition\, the task force covers WoT Binding Templ
+ ates topics to define the mapping from the abstract interaction model used
+  in the Thing Description metadata to concrete IoT protocols and payload e
+ ncodings.
+STATUS:CONFIRMED
+CREATED:20230529T112121Z
+LAST-MODIFIED:20230529T112220Z
+SEQUENCE:4
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:Zoom
+RELATED-TO:3f89692a-2708-45b6-bb12-b8f3e26ed35d
+RRULE:FREQ=WEEKLY;UNTIL=20230801T140000Z;INTERVAL=1;BYDAY=WE;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:6e165834-3ea7-4916-80b2-b9b360002bb1
+DTSTAMP:20220307T165159Z
+SUMMARY:WoT Architecture
+DTSTART;TZID=America/New_York:20220303T060000
+DTEND;TZID=America/New_York:20220303T070000
+DESCRIPTION:https://www.w3.org/events/meetings/6e165834-3ea7-4916-80b2-b9b3
+ 60002bb1\n\nThe [WoT Architecture task force](https://www.w3.org/WoT/IG/wi
+ ki/WG_WoT_Architecture_WebConf) is responsible for both the abstract archi
+ tecture and interoperability profiles for the Web of Things.\n\n[IRC: #wot
+ -arch](https://irc.w3.org/#channels=wot-arch) / [WebEx](https://lists.w3.o
+ rg/Archives/Member/member-wot-wg/2022Jan/0007.html)
+STATUS:CONFIRMED
+CREATED:20220301T204023Z
+LAST-MODIFIED:20220307T165159Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RRULE:FREQ=WEEKLY;UNTIL=20220303T110000Z;INTERVAL=1;BYDAY=TH;WKST=MO
+RELATED-TO:a079ed64-f38a-4bb7-ac9d-8c6ddfd90d75
+END:VEVENT
+BEGIN:VEVENT
+UID:a079ed64-f38a-4bb7-ac9d-8c6ddfd90d75
+DTSTAMP:20221019T125417Z
+SUMMARY:WoT Architecture
+DTSTART;TZID=America/New_York:20220310T060000
+DTEND;TZID=America/New_York:20220310T070000
+DESCRIPTION:https://www.w3.org/events/meetings/a079ed64-f38a-4bb7-ac9d-8c6d
+ dfd90d75\n\nThe [WoT Architecture task force](https://www.w3.org/WoT/IG/wi
+ ki/WG_WoT_Architecture_WebConf) is responsible for both the abstract archi
+ tecture and interoperability profiles for the Web of Things.\n\n[IRC: #wot
+ -arch](https://irc.w3.org/#channels=wot-arch) / [WebEx](https://lists.w3.o
+ rg/Archives/Member/member-wot-wg/2022Jan/0007.html)
+STATUS:CONFIRMED
+CREATED:20220307T165155Z
+LAST-MODIFIED:20221019T125417Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RELATED-TO:6e165834-3ea7-4916-80b2-b9b360002bb1
+RELATED-TO:c3be8053-68c1-42b2-88da-e76b683d8878
+RRULE:FREQ=WEEKLY;UNTIL=20221013T100000Z;INTERVAL=1;BYDAY=TH;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:a079ed64-f38a-4bb7-ac9d-8c6ddfd90d75
+DTSTAMP:20220309T152830Z
+SUMMARY:WoT Architecture
+DTSTART;TZID=America/New_York:20220317T060000
+DTEND;TZID=America/New_York:20220317T070000
+DESCRIPTION:https://www.w3.org/events/meetings/a079ed64-f38a-4bb7-ac9d-8c6d
+ dfd90d75/20220317T060000\n\nThe [WoT Architecture task force](https://www.
+ w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf) is responsible for both th
+ e abstract architecture and interoperability profiles for the Web of Thing
+ s.\n\n[IRC: #wot-arch](https://irc.w3.org/#channels=wot-arch) / [WebEx](ht
+ tps://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0007.html)
+STATUS:CANCELLED
+CREATED:20220309T152828Z
+LAST-MODIFIED:20220309T152830Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220317T060000
+END:VEVENT
+BEGIN:VEVENT
+UID:a079ed64-f38a-4bb7-ac9d-8c6ddfd90d75
+DTSTAMP:20220413T100628Z
+SUMMARY:WoT Architecture
+DTSTART;TZID=America/New_York:20220414T060000
+DTEND;TZID=America/New_York:20220414T070000
+DESCRIPTION:https://www.w3.org/events/meetings/a079ed64-f38a-4bb7-ac9d-8c6d
+ dfd90d75/20220414T060000\n\nThe [WoT Architecture task force](https://www.
+ w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf) is responsible for both th
+ e abstract architecture and interoperability profiles for the Web of Thing
+ s.\n\n[IRC: #wot-arch](https://irc.w3.org/#channels=wot-arch) / [WebEx](ht
+ tps://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0007.html)
+STATUS:CANCELLED
+CREATED:20220413T100556Z
+LAST-MODIFIED:20220413T100628Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220414T060000
+END:VEVENT
+BEGIN:VEVENT
+UID:a079ed64-f38a-4bb7-ac9d-8c6ddfd90d75
+DTSTAMP:20220413T101017Z
+SUMMARY:WoT Architecture
+DTSTART;TZID=America/New_York:20220421T060000
+DTEND;TZID=America/New_York:20220421T070000
+DESCRIPTION:https://www.w3.org/events/meetings/a079ed64-f38a-4bb7-ac9d-8c6d
+ dfd90d75/20220421T060000\n\nThe [WoT Architecture task force](https://www.
+ w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf) is responsible for both th
+ e abstract architecture and interoperability profiles for the Web of Thing
+ s.\n\n[IRC: #wot-arch](https://irc.w3.org/#channels=wot-arch) / [WebEx](ht
+ tps://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0007.html)
+STATUS:CANCELLED
+CREATED:20220413T101016Z
+LAST-MODIFIED:20220413T101017Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220421T060000
+END:VEVENT
+BEGIN:VEVENT
+UID:a079ed64-f38a-4bb7-ac9d-8c6ddfd90d75
+DTSTAMP:20220601T100730Z
+SUMMARY:WoT Architecture
+DTSTART;TZID=America/New_York:20220602T060000
+DTEND;TZID=America/New_York:20220602T070000
+DESCRIPTION:https://www.w3.org/events/meetings/a079ed64-f38a-4bb7-ac9d-8c6d
+ dfd90d75/20220602T060000\n\nThe [WoT Architecture task force](https://www.
+ w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf) is responsible for both th
+ e abstract architecture and interoperability profiles for the Web of Thing
+ s.\n\n[IRC: #wot-arch](https://irc.w3.org/#channels=wot-arch) / [WebEx](ht
+ tps://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0007.html)
+STATUS:CANCELLED
+CREATED:20220601T100728Z
+LAST-MODIFIED:20220601T100730Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220602T060000
+END:VEVENT
+BEGIN:VEVENT
+UID:a079ed64-f38a-4bb7-ac9d-8c6ddfd90d75
+DTSTAMP:20220608T102536Z
+SUMMARY:WoT Architecture
+DTSTART;TZID=America/New_York:20220609T060000
+DTEND;TZID=America/New_York:20220609T070000
+DESCRIPTION:https://www.w3.org/events/meetings/a079ed64-f38a-4bb7-ac9d-8c6d
+ dfd90d75/20220609T060000\n\nThe [WoT Architecture task force](https://www.
+ w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf) is responsible for both th
+ e abstract architecture and interoperability profiles for the Web of Thing
+ s.\n\n[IRC: #wot-arch](https://irc.w3.org/#channels=wot-arch) / [WebEx](ht
+ tps://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0007.html)
+STATUS:CANCELLED
+CREATED:20220608T102535Z
+LAST-MODIFIED:20220608T102536Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220609T060000
+END:VEVENT
+BEGIN:VEVENT
+UID:a079ed64-f38a-4bb7-ac9d-8c6ddfd90d75
+DTSTAMP:20220706T112517Z
+SUMMARY:WoT Architecture
+DTSTART;TZID=America/New_York:20220707T060000
+DTEND;TZID=America/New_York:20220707T070000
+DESCRIPTION:https://www.w3.org/events/meetings/a079ed64-f38a-4bb7-ac9d-8c6d
+ dfd90d75/20220707T060000\n\nThe [WoT Architecture task force](https://www.
+ w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf) is responsible for both th
+ e abstract architecture and interoperability profiles for the Web of Thing
+ s.\n\n[IRC: #wot-arch](https://irc.w3.org/#channels=wot-arch) / [WebEx](ht
+ tps://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0007.html)
+STATUS:CANCELLED
+CREATED:20220706T112516Z
+LAST-MODIFIED:20220706T112517Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220707T060000
+END:VEVENT
+BEGIN:VEVENT
+UID:a079ed64-f38a-4bb7-ac9d-8c6ddfd90d75
+DTSTAMP:20220725T120329Z
+SUMMARY:WoT Architecture
+DTSTART;TZID=America/New_York:20220728T060000
+DTEND;TZID=America/New_York:20220728T070000
+DESCRIPTION:https://www.w3.org/events/meetings/a079ed64-f38a-4bb7-ac9d-8c6d
+ dfd90d75/20220728T060000\n\nThe [WoT Architecture task force](https://www.
+ w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf) is responsible for both th
+ e abstract architecture and interoperability profiles for the Web of Thing
+ s.\n\n[IRC: #wot-arch](https://irc.w3.org/#channels=wot-arch) / [WebEx](ht
+ tps://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0007.html)
+STATUS:CANCELLED
+CREATED:20220725T120328Z
+LAST-MODIFIED:20220725T120329Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220728T060000
+END:VEVENT
+BEGIN:VEVENT
+UID:a079ed64-f38a-4bb7-ac9d-8c6ddfd90d75
+DTSTAMP:20220810T100229Z
+SUMMARY:WoT Architecture
+DTSTART;TZID=America/New_York:20220811T060000
+DTEND;TZID=America/New_York:20220811T070000
+DESCRIPTION:https://www.w3.org/events/meetings/a079ed64-f38a-4bb7-ac9d-8c6d
+ dfd90d75/20220811T060000\n\nThe [WoT Architecture task force](https://www.
+ w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf) is responsible for both th
+ e abstract architecture and interoperability profiles for the Web of Thing
+ s.\n\n[IRC: #wot-arch](https://irc.w3.org/#channels=wot-arch) / [WebEx](ht
+ tps://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0007.html)
+STATUS:CANCELLED
+CREATED:20220810T100227Z
+LAST-MODIFIED:20220810T100229Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220811T060000
+END:VEVENT
+BEGIN:VEVENT
+UID:a079ed64-f38a-4bb7-ac9d-8c6ddfd90d75
+DTSTAMP:20220823T131136Z
+SUMMARY:WoT Architecture
+DTSTART;TZID=America/New_York:20220825T060000
+DTEND;TZID=America/New_York:20220825T070000
+DESCRIPTION:https://www.w3.org/events/meetings/a079ed64-f38a-4bb7-ac9d-8c6d
+ dfd90d75/20220825T060000\n\nThe [WoT Architecture task force](https://www.
+ w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf) is responsible for both th
+ e abstract architecture and interoperability profiles for the Web of Thing
+ s.\n\n[IRC: #wot-arch](https://irc.w3.org/#channels=wot-arch) / [WebEx](ht
+ tps://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0007.html)
+STATUS:CANCELLED
+CREATED:20220823T131135Z
+LAST-MODIFIED:20220823T131136Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220825T060000
+END:VEVENT
+BEGIN:VEVENT
+UID:a079ed64-f38a-4bb7-ac9d-8c6ddfd90d75
+DTSTAMP:20220831T162310Z
+SUMMARY:WoT Architecture
+DTSTART;TZID=America/New_York:20220915T060000
+DTEND;TZID=America/New_York:20220915T070000
+DESCRIPTION:https://www.w3.org/events/meetings/a079ed64-f38a-4bb7-ac9d-8c6d
+ dfd90d75/20220915T060000\n\nThe [WoT Architecture task force](https://www.
+ w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf) is responsible for both th
+ e abstract architecture and interoperability profiles for the Web of Thing
+ s.\n\n[IRC: #wot-arch](https://irc.w3.org/#channels=wot-arch) / [WebEx](ht
+ tps://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0007.html)
+STATUS:CANCELLED
+CREATED:20220831T162308Z
+LAST-MODIFIED:20220831T162310Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220915T060000
+END:VEVENT
+BEGIN:VEVENT
+UID:c3be8053-68c1-42b2-88da-e76b683d8878
+DTSTAMP:20230201T171024Z
+SUMMARY:WoT Architecture
+DTSTART;TZID=America/New_York:20221020T060000
+DTEND;TZID=America/New_York:20221020T070000
+DESCRIPTION:https://www.w3.org/events/meetings/c3be8053-68c1-42b2-88da-e76b
+ 683d8878\n\nThe [WoT Architecture task force](https://www.w3.org/WoT/IG/wi
+ ki/WG_WoT_Architecture_WebConf) is responsible for both the abstract archi
+ tecture and interoperability profiles for the Web of Things.\n\n[IRC: #wot
+ -arch](https://irc.w3.org/#channels=wot-arch) / [WebEx](https://lists.w3.o
+ rg/Archives/Member/member-wot-wg/2022Jan/0007.html)
+STATUS:CONFIRMED
+CREATED:20221019T125417Z
+LAST-MODIFIED:20230201T171024Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RELATED-TO:a079ed64-f38a-4bb7-ac9d-8c6ddfd90d75
+RELATED-TO:7e8cb7d2-3be4-46d2-96a5-4ae08da07125
+RRULE:FREQ=WEEKLY;UNTIL=20230105T110000Z;INTERVAL=1;BYDAY=TH;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:c3be8053-68c1-42b2-88da-e76b683d8878
+DTSTAMP:20221207T165922Z
+SUMMARY:WoT Architecture
+DTSTART;TZID=America/New_York:20221215T060000
+DTEND;TZID=America/New_York:20221215T070000
+DESCRIPTION:https://www.w3.org/events/meetings/c3be8053-68c1-42b2-88da-e76b
+ 683d8878/20221215T060000\n\nThe [WoT Architecture task force](https://www.
+ w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf) is responsible for both th
+ e abstract architecture and interoperability profiles for the Web of Thing
+ s.\n\n[IRC: #wot-arch](https://irc.w3.org/#channels=wot-arch) / [WebEx](ht
+ tps://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0007.html)
+STATUS:CANCELLED
+CREATED:20221207T165921Z
+LAST-MODIFIED:20221207T165922Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20221215T060000
+END:VEVENT
+BEGIN:VEVENT
+UID:7e8cb7d2-3be4-46d2-96a5-4ae08da07125
+DTSTAMP:20230530T122114Z
+SUMMARY:WoT Architecture
+DTSTART;TZID=America/New_York:20230112T060000
+DTEND;TZID=America/New_York:20230112T070000
+DESCRIPTION:https://www.w3.org/events/meetings/7e8cb7d2-3be4-46d2-96a5-4ae0
+ 8da07125\n\nThe [WoT Architecture task force](https://www.w3.org/WoT/IG/wi
+ ki/WG_WoT_Architecture_WebConf) is responsible for both the abstract archi
+ tecture and interoperability profiles for the Web of Things.\n\n[IRC: #wot
+ -arch](https://irc.w3.org/#channels=wot-arch) / [WebEx](https://lists.w3.o
+ rg/Archives/Member/member-wot-wg/2022Jan/0007.html)
+STATUS:CONFIRMED
+CREATED:20230201T171022Z
+LAST-MODIFIED:20230530T122114Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RELATED-TO:c3be8053-68c1-42b2-88da-e76b683d8878
+RELATED-TO:576fde8d-1311-44d6-9437-75803fb04256
+RRULE:FREQ=WEEKLY;UNTIL=20230525T100000Z;INTERVAL=1;BYDAY=TH;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:7e8cb7d2-3be4-46d2-96a5-4ae08da07125
+DTSTAMP:20230201T171025Z
+SUMMARY:WoT Architecture
+DTSTART;TZID=America/New_York:20230119T060000
+DTEND;TZID=America/New_York:20230119T070000
+DESCRIPTION:https://www.w3.org/events/meetings/7e8cb7d2-3be4-46d2-96a5-4ae0
+ 8da07125/20230119T060000\n\nThe [WoT Architecture task force](https://www.
+ w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf) is responsible for both th
+ e abstract architecture and interoperability profiles for the Web of Thing
+ s.\n\n[IRC: #wot-arch](https://irc.w3.org/#channels=wot-arch) / [WebEx](ht
+ tps://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0007.html)
+STATUS:CANCELLED
+CREATED:20230111T112411Z
+LAST-MODIFIED:20230201T171025Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20230119T060000
+END:VEVENT
+BEGIN:VEVENT
+UID:7e8cb7d2-3be4-46d2-96a5-4ae08da07125
+DTSTAMP:20230201T171026Z
+SUMMARY:WoT Architecture
+DTSTART;TZID=America/New_York:20230126T060000
+DTEND;TZID=America/New_York:20230126T070000
+DESCRIPTION:https://www.w3.org/events/meetings/7e8cb7d2-3be4-46d2-96a5-4ae0
+ 8da07125/20230126T060000\n\nThe [WoT Architecture task force](https://www.
+ w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf) is responsible for both th
+ e abstract architecture and interoperability profiles for the Web of Thing
+ s.\n\n[IRC: #wot-arch](https://irc.w3.org/#channels=wot-arch) / [WebEx](ht
+ tps://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0007.html)
+STATUS:CANCELLED
+CREATED:20230126T094627Z
+LAST-MODIFIED:20230201T171026Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20230126T060000
+END:VEVENT
+BEGIN:VEVENT
+UID:7e8cb7d2-3be4-46d2-96a5-4ae08da07125
+DTSTAMP:20230202T162305Z
+SUMMARY:WoT Architecture
+DTSTART;TZID=America/New_York:20230201T060000
+DTEND;TZID=America/New_York:20230201T070000
+DESCRIPTION:https://www.w3.org/events/meetings/7e8cb7d2-3be4-46d2-96a5-4ae0
+ 8da07125/20230209T060000\n\nThe [WoT Architecture task force](https://www.
+ w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf) is responsible for both th
+ e abstract architecture and interoperability profiles for the Web of Thing
+ s.\n\n[IRC: #wot-arch](https://irc.w3.org/#channels=wot-arch) / [WebEx](ht
+ tps://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0007.html)
+STATUS:CONFIRMED
+CREATED:20230202T162305Z
+LAST-MODIFIED:20230202T162305Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20230209T060000
+END:VEVENT
+BEGIN:VEVENT
+UID:7e8cb7d2-3be4-46d2-96a5-4ae08da07125
+DTSTAMP:20230212T225826Z
+SUMMARY:CANCELLED WoT Architecture
+DTSTART;TZID=America/New_York:20230216T060000
+DTEND;TZID=America/New_York:20230216T070000
+DESCRIPTION:https://www.w3.org/events/meetings/7e8cb7d2-3be4-46d2-96a5-4ae0
+ 8da07125/20230216T060000\n\nThe [WoT Architecture task force](https://www.
+ w3.org/WoT/IG/wiki/WG_WoT_Architecture_WebConf) is responsible for both th
+ e abstract architecture and interoperability profiles for the Web of Thing
+ s.\n\n[IRC: #wot-arch](https://irc.w3.org/#channels=wot-arch) / [WebEx](ht
+ tps://lists.w3.org/Archives/Member/member-wot-wg/2022Jan/0007.html)
+STATUS:TENTATIVE
+CREATED:20230212T225824Z
+LAST-MODIFIED:20230212T225826Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20230216T060000
+END:VEVENT
+BEGIN:VEVENT
+UID:576fde8d-1311-44d6-9437-75803fb04256
+DTSTAMP:20230530T122114Z
+SUMMARY:WoT Architecture
+DTSTART;TZID=America/New_York:20230601T060000
+DTEND;TZID=America/New_York:20230601T070000
+DESCRIPTION:https://www.w3.org/events/meetings/576fde8d-1311-44d6-9437-7580
+ 3fb04256\n\nThe [WoT Architecture task force](https://www.w3.org/WoT/IG/wi
+ ki/WG_WoT_Architecture_WebConf) is responsible for  the abstract architect
+ ure for the Web of Things.\n\n[IRC: #wot-arch](https://irc.w3.org/#channel
+ s=wot-arch) / [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2
+ 022Jan/0007.html)
+STATUS:CONFIRMED
+CREATED:20230530T122114Z
+LAST-MODIFIED:20230530T122114Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:Zoom
+RELATED-TO:7e8cb7d2-3be4-46d2-96a5-4ae08da07125
+RRULE:FREQ=WEEKLY;UNTIL=20230801T100000Z;INTERVAL=1;BYDAY=TH;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:5f1f59b0-175e-478d-8385-03e16841e8b8
+DTSTAMP:20220307T164927Z
+SUMMARY:WoT Testing
+DTSTART;TZID=America/New_York:20220302T090000
+DTEND;TZID=America/New_York:20220302T100000
+DESCRIPTION:https://www.w3.org/events/meetings/5f1f59b0-175e-478d-8385-03e1
+ 6841e8b8\n\nThe [WoT Plugfest/Testing task force](https://www.w3.org/WoT/I
+ G/wiki/PlugFest_WebConf) is responsible for organizing the Web of Things (
+ WoT) Plugfests and also for organizing general testing procedures\, data c
+ ollection\, and implementation report tooling for WoT deliverables.\n\nNot
+ e that the Testing/Plugfest call uses the same WebEx as the WoT Main call\
+ , but a different IRC channel.\n\n[IRC: #wot-pf](https://irc.w3.org/?chann
+ els=wot-pf) / [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2
+ 020Jul/0052.html)
+STATUS:CONFIRMED
+CREATED:20220301T204430Z
+LAST-MODIFIED:20220307T164927Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RRULE:FREQ=WEEKLY;UNTIL=20220302T140000Z;INTERVAL=1;BYDAY=WE;WKST=MO
+RELATED-TO:6d818d5c-b255-4483-a7c5-a609928644a6
+END:VEVENT
+BEGIN:VEVENT
+UID:6d818d5c-b255-4483-a7c5-a609928644a6
+DTSTAMP:20230201T170348Z
+SUMMARY:WoT Testing
+DTSTART;TZID=America/New_York:20220309T090000
+DTEND;TZID=America/New_York:20220309T100000
+DESCRIPTION:https://www.w3.org/events/meetings/6d818d5c-b255-4483-a7c5-a609
+ 928644a6\n\nThe [WoT Plugfest/Testing task force](https://www.w3.org/WoT/I
+ G/wiki/PlugFest_WebConf) is responsible for organizing the Web of Things (
+ WoT) Plugfests and also for organizing general testing procedures\, data c
+ ollection\, and implementation report tooling for WoT deliverables.\n\nNot
+ e that the Testing/Plugfest call uses the same WebEx as the WoT Main call\
+ , but a different IRC channel.\n\n[IRC: #wot-pf](https://irc.w3.org/?chann
+ els=wot-pf) / [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2
+ 020Jul/0052.html)
+STATUS:CONFIRMED
+CREATED:20220307T164924Z
+LAST-MODIFIED:20230201T170348Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RELATED-TO:5f1f59b0-175e-478d-8385-03e16841e8b8
+RELATED-TO:0f4fbf77-e620-4ec1-865a-28d5d2f4fe38
+RRULE:FREQ=WEEKLY;UNTIL=20230125T140000Z;INTERVAL=1;BYDAY=WE;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:6d818d5c-b255-4483-a7c5-a609928644a6
+DTSTAMP:20220309T152716Z
+SUMMARY:WoT Testing
+DTSTART;TZID=America/New_York:20220316T090000
+DTEND;TZID=America/New_York:20220316T100000
+DESCRIPTION:https://www.w3.org/events/meetings/6d818d5c-b255-4483-a7c5-a609
+ 928644a6/20220316T090000\n\nThe [WoT Plugfest/Testing task force](https://
+ www.w3.org/WoT/IG/wiki/PlugFest_WebConf) is responsible for organizing the
+  Web of Things (WoT) Plugfests and also for organizing general testing pro
+ cedures\, data collection\, and implementation report tooling for WoT deli
+ verables.\n\nNote that the Testing/Plugfest call uses the same WebEx as th
+ e WoT Main call\, but a different IRC channel.\n\n[IRC: #wot-pf](https://i
+ rc.w3.org/?channels=wot-pf) / [WebEx](https://lists.w3.org/Archives/Member
+ /member-wot-wg/2020Jul/0052.html)
+STATUS:CANCELLED
+CREATED:20220309T152714Z
+LAST-MODIFIED:20220309T152716Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220316T090000
+END:VEVENT
+BEGIN:VEVENT
+UID:6d818d5c-b255-4483-a7c5-a609928644a6
+DTSTAMP:20220720T144115Z
+SUMMARY:WoT Testing
+DTSTART;TZID=America/New_York:20220727T090000
+DTEND;TZID=America/New_York:20220727T100000
+DESCRIPTION:https://www.w3.org/events/meetings/6d818d5c-b255-4483-a7c5-a609
+ 928644a6/20220727T090000\n\nThe [WoT Plugfest/Testing task force](https://
+ www.w3.org/WoT/IG/wiki/PlugFest_WebConf) is responsible for organizing the
+  Web of Things (WoT) Plugfests and also for organizing general testing pro
+ cedures\, data collection\, and implementation report tooling for WoT deli
+ verables.\n\nNote that the Testing/Plugfest call uses the same WebEx as th
+ e WoT Main call\, but a different IRC channel.\n\n[IRC: #wot-pf](https://i
+ rc.w3.org/?channels=wot-pf) / [WebEx](https://lists.w3.org/Archives/Member
+ /member-wot-wg/2020Jul/0052.html)
+STATUS:CANCELLED
+CREATED:20220720T144114Z
+LAST-MODIFIED:20220720T144115Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220727T090000
+END:VEVENT
+BEGIN:VEVENT
+UID:6d818d5c-b255-4483-a7c5-a609928644a6
+DTSTAMP:20220831T161347Z
+SUMMARY:WoT Testing
+DTSTART;TZID=America/New_York:20220907T090000
+DTEND;TZID=America/New_York:20220907T100000
+DESCRIPTION:https://www.w3.org/events/meetings/6d818d5c-b255-4483-a7c5-a609
+ 928644a6/20220907T090000\n\nThe [WoT Plugfest/Testing task force](https://
+ www.w3.org/WoT/IG/wiki/PlugFest_WebConf) is responsible for organizing the
+  Web of Things (WoT) Plugfests and also for organizing general testing pro
+ cedures\, data collection\, and implementation report tooling for WoT deli
+ verables.\n\nNote that the Testing/Plugfest call uses the same WebEx as th
+ e WoT Main call\, but a different IRC channel.\n\n[IRC: #wot-pf](https://i
+ rc.w3.org/?channels=wot-pf) / [WebEx](https://lists.w3.org/Archives/Member
+ /member-wot-wg/2020Jul/0052.html)
+STATUS:CANCELLED
+CREATED:20220831T161346Z
+LAST-MODIFIED:20220831T161347Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220907T090000
+END:VEVENT
+BEGIN:VEVENT
+UID:6d818d5c-b255-4483-a7c5-a609928644a6
+DTSTAMP:20220831T162326Z
+SUMMARY:WoT Testing
+DTSTART;TZID=America/New_York:20220914T090000
+DTEND;TZID=America/New_York:20220914T100000
+DESCRIPTION:https://www.w3.org/events/meetings/6d818d5c-b255-4483-a7c5-a609
+ 928644a6/20220914T090000\n\nThe [WoT Plugfest/Testing task force](https://
+ www.w3.org/WoT/IG/wiki/PlugFest_WebConf) is responsible for organizing the
+  Web of Things (WoT) Plugfests and also for organizing general testing pro
+ cedures\, data collection\, and implementation report tooling for WoT deli
+ verables.\n\nNote that the Testing/Plugfest call uses the same WebEx as th
+ e WoT Main call\, but a different IRC channel.\n\n[IRC: #wot-pf](https://i
+ rc.w3.org/?channels=wot-pf) / [WebEx](https://lists.w3.org/Archives/Member
+ /member-wot-wg/2020Jul/0052.html)
+STATUS:CANCELLED
+CREATED:20220831T162149Z
+LAST-MODIFIED:20220831T162326Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220914T090000
+END:VEVENT
+BEGIN:VEVENT
+UID:6d818d5c-b255-4483-a7c5-a609928644a6
+DTSTAMP:20220916T131852Z
+SUMMARY:WoT Testing
+DTSTART;TZID=America/New_York:20220921T090000
+DTEND;TZID=America/New_York:20220921T100000
+DESCRIPTION:https://www.w3.org/events/meetings/6d818d5c-b255-4483-a7c5-a609
+ 928644a6/20220921T090000\n\nThe [WoT Plugfest/Testing task force](https://
+ www.w3.org/WoT/IG/wiki/PlugFest_WebConf) is responsible for organizing the
+  Web of Things (WoT) Plugfests and also for organizing general testing pro
+ cedures\, data collection\, and implementation report tooling for WoT deli
+ verables.\n\nNote that the Testing/Plugfest call uses the same WebEx as th
+ e WoT Main call\, but a different IRC channel.\n\n[IRC: #wot-pf](https://i
+ rc.w3.org/?channels=wot-pf) / [WebEx](https://lists.w3.org/Archives/Member
+ /member-wot-wg/2020Jul/0052.html)
+STATUS:CANCELLED
+CREATED:20220916T131851Z
+LAST-MODIFIED:20220916T131852Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220921T090000
+END:VEVENT
+BEGIN:VEVENT
+UID:6d818d5c-b255-4483-a7c5-a609928644a6
+DTSTAMP:20221003T110055Z
+SUMMARY:WoT Testing
+DTSTART;TZID=America/New_York:20221005T090000
+DTEND;TZID=America/New_York:20221005T100000
+DESCRIPTION:https://www.w3.org/events/meetings/6d818d5c-b255-4483-a7c5-a609
+ 928644a6/20221005T090000\n\nThe [WoT Plugfest/Testing task force](https://
+ www.w3.org/WoT/IG/wiki/PlugFest_WebConf) is responsible for organizing the
+  Web of Things (WoT) Plugfests and also for organizing general testing pro
+ cedures\, data collection\, and implementation report tooling for WoT deli
+ verables.\n\nNote that the Testing/Plugfest call uses the same WebEx as th
+ e WoT Main call\, but a different IRC channel.\n\n[IRC: #wot-pf](https://i
+ rc.w3.org/?channels=wot-pf) / [WebEx](https://lists.w3.org/Archives/Member
+ /member-wot-wg/2020Jul/0052.html)
+STATUS:CANCELLED
+CREATED:20221003T110054Z
+LAST-MODIFIED:20221003T110055Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20221005T090000
+END:VEVENT
+BEGIN:VEVENT
+UID:6d818d5c-b255-4483-a7c5-a609928644a6
+DTSTAMP:20221207T165830Z
+SUMMARY:WoT Testing
+DTSTART;TZID=America/New_York:20221214T090000
+DTEND;TZID=America/New_York:20221214T100000
+DESCRIPTION:https://www.w3.org/events/meetings/6d818d5c-b255-4483-a7c5-a609
+ 928644a6/20221214T090000\n\nThe [WoT Plugfest/Testing task force](https://
+ www.w3.org/WoT/IG/wiki/PlugFest_WebConf) is responsible for organizing the
+  Web of Things (WoT) Plugfests and also for organizing general testing pro
+ cedures\, data collection\, and implementation report tooling for WoT deli
+ verables.\n\nNote that the Testing/Plugfest call uses the same WebEx as th
+ e WoT Main call\, but a different IRC channel.\n\n[IRC: #wot-pf](https://i
+ rc.w3.org/?channels=wot-pf) / [WebEx](https://lists.w3.org/Archives/Member
+ /member-wot-wg/2020Jul/0052.html)
+STATUS:CANCELLED
+CREATED:20221207T165829Z
+LAST-MODIFIED:20221207T165830Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20221214T090000
+END:VEVENT
+BEGIN:VEVENT
+UID:6d818d5c-b255-4483-a7c5-a609928644a6
+DTSTAMP:20230111T112312Z
+SUMMARY:WoT Testing
+DTSTART;TZID=America/New_York:20230118T090000
+DTEND;TZID=America/New_York:20230118T100000
+DESCRIPTION:https://www.w3.org/events/meetings/6d818d5c-b255-4483-a7c5-a609
+ 928644a6/20230118T090000\n\nThe [WoT Plugfest/Testing task force](https://
+ www.w3.org/WoT/IG/wiki/PlugFest_WebConf) is responsible for organizing the
+  Web of Things (WoT) Plugfests and also for organizing general testing pro
+ cedures\, data collection\, and implementation report tooling for WoT deli
+ verables.\n\nNote that the Testing/Plugfest call uses the same WebEx as th
+ e WoT Main call\, but a different IRC channel.\n\n[IRC: #wot-pf](https://i
+ rc.w3.org/?channels=wot-pf) / [WebEx](https://lists.w3.org/Archives/Member
+ /member-wot-wg/2020Jul/0052.html)
+STATUS:CANCELLED
+CREATED:20230111T112311Z
+LAST-MODIFIED:20230111T112312Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20230118T090000
+END:VEVENT
+BEGIN:VEVENT
+UID:0f4fbf77-e620-4ec1-865a-28d5d2f4fe38
+DTSTAMP:20230529T111501Z
+SUMMARY:WoT Testing
+DTSTART;TZID=America/New_York:20230201T090000
+DTEND;TZID=America/New_York:20230201T100000
+DESCRIPTION:https://www.w3.org/events/meetings/0f4fbf77-e620-4ec1-865a-28d5
+ d2f4fe38\n\nThe [WoT Plugfest/Testing task force](https://www.w3.org/WoT/I
+ G/wiki/PlugFest_WebConf) is responsible for organizing the Web of Things (
+ WoT) Plugfests and also for organizing general testing procedures\, data c
+ ollection\, and implementation report tooling for WoT deliverables.\n\nNot
+ e that the Testing/Plugfest call uses the same WebEx as the WoT Main call\
+ , but a different IRC channel.\n\n[IRC: #wot-pf](https://irc.w3.org/?chann
+ els=wot-pf) / [WebEx](https://lists.w3.org/Archives/Member/member-wot-wg/2
+ 020Jul/0052.html)
+STATUS:CONFIRMED
+CREATED:20230201T170346Z
+LAST-MODIFIED:20230529T111501Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RELATED-TO:6d818d5c-b255-4483-a7c5-a609928644a6
+RELATED-TO:776bbadd-fa64-4e70-8be0-894be2f9ce70
+RRULE:FREQ=WEEKLY;UNTIL=20230524T130000Z;INTERVAL=1;BYDAY=WE;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:0f4fbf77-e620-4ec1-865a-28d5d2f4fe38
+DTSTAMP:20230212T225738Z
+SUMMARY:CANCELLED WoT Testing
+DTSTART;TZID=America/New_York:20230215T090000
+DTEND;TZID=America/New_York:20230215T100000
+DESCRIPTION:https://www.w3.org/events/meetings/0f4fbf77-e620-4ec1-865a-28d5
+ d2f4fe38/20230215T090000\n\nThe [WoT Plugfest/Testing task force](https://
+ www.w3.org/WoT/IG/wiki/PlugFest_WebConf) is responsible for organizing the
+  Web of Things (WoT) Plugfests and also for organizing general testing pro
+ cedures\, data collection\, and implementation report tooling for WoT deli
+ verables.\n\nNote that the Testing/Plugfest call uses the same WebEx as th
+ e WoT Main call\, but a different IRC channel.\n\n[IRC: #wot-pf](https://i
+ rc.w3.org/?channels=wot-pf) / [WebEx](https://lists.w3.org/Archives/Member
+ /member-wot-wg/2020Jul/0052.html)
+STATUS:TENTATIVE
+CREATED:20230212T225737Z
+LAST-MODIFIED:20230212T225738Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20230215T090000
+END:VEVENT
+BEGIN:VEVENT
+UID:776bbadd-fa64-4e70-8be0-894be2f9ce70
+DTSTAMP:20230529T111623Z
+SUMMARY:WoT Testing
+DTSTART;TZID=America/New_York:20230531T090000
+DTEND;TZID=America/New_York:20230531T100000
+DESCRIPTION:https://www.w3.org/events/meetings/776bbadd-fa64-4e70-8be0-894b
+ e2f9ce70\n\nThe [WoT Plugfest/Testing task force](https://www.w3.org/WoT/I
+ G/wiki/PlugFest_WebConf) is responsible for organizing the Web of Things (
+ WoT) Plugfests and also for organizing general testing procedures\, data c
+ ollection\, and implementation report tooling for WoT deliverables.\n\n'''
+ Note:''' We used to reused the WebEx coordinate for the WoT main call for 
+ the Testing call\, but a dedicated Zoom call has been generated for the Te
+ sting call.
+STATUS:CONFIRMED
+CREATED:20230529T111501Z
+LAST-MODIFIED:20230529T111623Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:Zoom
+RELATED-TO:0f4fbf77-e620-4ec1-865a-28d5d2f4fe38
+RRULE:FREQ=WEEKLY;UNTIL=20230801T130000Z;INTERVAL=1;BYDAY=WE;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:e4152295-253a-43e6-9bd4-4fd1105de206
+DTSTAMP:20220309T152029Z
+SUMMARY:WoT Testfest
+DTSTART;TZID=America/New_York:20220314T080000
+DTEND;TZID=America/New_York:20220314T090000
+DESCRIPTION:https://www.w3.org/events/meetings/e4152295-253a-43e6-9bd4-4fd1
+ 105de206\n\nDaily call during Testfest/Plugfest week to discuss testing of
+  current deliverables\, focused on updating implementation report drafts.\
+ n\nSee https://github.com/w3c/wot-testing/tree/main/events/2022.03.Online\
+ n\nNotes: \n1. Experimental implementations and non-WG members should use 
+ the Plugfest call instead (using same WebEx\, but an hour later).\n2. Othe
+ r WoT meetings this week may be cancelled\, please check.\n3. This is also
+  the week that Daylight Savings changes in the US\, and the meeting is set
+  up relative to the US Eastern time zone so meetings may be delayed by an 
+ hour relative to the previous week in other timezones.\n\n[IRC: #wot-pf](h
+ ttps://irc.w3.org/?channels=wot-pf) / [WebEx](https://lists.w3.org/Archive
+ s/Member/member-wot-ig/2022Mar/0002.html)
+STATUS:CONFIRMED
+CREATED:20220302T145946Z
+LAST-MODIFIED:20220309T152029Z
+SEQUENCE:0
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RRULE:FREQ=DAILY;UNTIL=20220318T120000Z;INTERVAL=1;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:e4152295-253a-43e6-9bd4-4fd1105de206
+DTSTAMP:20220315T141958Z
+SUMMARY:WoT Testfest
+DTSTART;TZID=America/New_York:20220316T090000
+DTEND;TZID=America/New_York:20220316T100000
+DESCRIPTION:https://www.w3.org/events/meetings/e4152295-253a-43e6-9bd4-4fd1
+ 105de206/20220316T080000\n\nDaily call during Testfest/Plugfest week to di
+ scuss testing of current deliverables\, focused on updating implementation
+  report drafts.\n\nNOTE: This event is an exception\, and is an hour later
+  than other Testfest calls this week.\n\nSee https://github.com/w3c/wot-te
+ sting/tree/main/events/2022.03.Online\n\nNotes: \n1. Experimental implemen
+ tations and non-WG members should use the Plugfest call instead (using sam
+ e WebEx\, but an hour later).\n2. Other WoT meetings this week may be canc
+ elled\, please check.\n3. This is also the week that Daylight Savings chan
+ ges in the US\, and the meeting is set up relative to the US Eastern time 
+ zone so meetings may be delayed by an hour relative to the previous week i
+ n other timezones.\n\n[IRC: #wot-tf](https://irc.w3.org/?channels=wot-tf) 
+ / [WebEx](https://lists.w3.org/Archives/Member/member-wot-ig/2022Mar/0002.
+ html)
+STATUS:CONFIRMED
+CREATED:20220309T152422Z
+LAST-MODIFIED:20220315T141958Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220316T080000
+END:VEVENT
+BEGIN:VEVENT
+UID:7b396436-d705-43ea-84c7-87b3ebdb8042
+DTSTAMP:20220309T152111Z
+SUMMARY:WoT Plugfest
+DTSTART;TZID=America/New_York:20220314T090000
+DTEND;TZID=America/New_York:20220314T100000
+DESCRIPTION:https://www.w3.org/events/meetings/7b396436-d705-43ea-84c7-87b3
+ ebdb8042\n\nDaily call during Testfest/Plugfest week to discuss testing of
+  experimental and new features\, focused on interoperability.\n\nSee https
+ ://github.com/w3c/wot-testing/tree/main/events/2022.03.Online\n\nNotes: \n
+ 1. Testing of current deliverables by WG members should use the Testfest c
+ all instead (using same WebEx\, but starts an hour earlier).\n2. Other WoT
+  meetings this week may be cancelled\, please check.\n3. This is also the 
+ week that Daylight Savings changes in the US\, and the meeting is set up r
+ elative to the US Eastern time zone so meetings may be delayed by an hour 
+ relative to the previous week in other timezones.\n\n[IRC: #wot-pf](https:
+ //irc.w3.org/?channels=wot-pf) / [WebEx](https://lists.w3.org/Archives/Mem
+ ber/member-wot-ig/2022Mar/0002.html)
+STATUS:CONFIRMED
+CREATED:20220302T150249Z
+LAST-MODIFIED:20220309T152111Z
+SEQUENCE:0
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RRULE:FREQ=DAILY;UNTIL=20220318T130000Z;INTERVAL=1;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:7b396436-d705-43ea-84c7-87b3ebdb8042
+DTSTAMP:20220315T142034Z
+SUMMARY:WoT Plugfest
+DTSTART;TZID=America/New_York:20220316T100000
+DTEND;TZID=America/New_York:20220316T110000
+DESCRIPTION:https://www.w3.org/events/meetings/7b396436-d705-43ea-84c7-87b3
+ ebdb8042/20220316T090000\n\nDaily call during Testfest/Plugfest week to di
+ scuss testing of experimental and new features\, focused on interoperabili
+ ty.\n\nNOTE: This event is an exception\, and is an hour later than other 
+ Plugfest calls this week.\n\nSee https://github.com/w3c/wot-testing/tree/m
+ ain/events/2022.03.Online\n\nNotes: \n1. Testing of current deliverables b
+ y WG members should use the Testfest call instead (using same WebEx\, but 
+ starts an hour earlier).\n2. Other WoT meetings this week may be cancelled
+ \, please check.\n3. This is also the week that Daylight Savings changes i
+ n the US\, and the meeting is set up relative to the US Eastern time zone 
+ so meetings may be delayed by an hour relative to the previous week in oth
+ er timezones.\n\n[IRC: #wot-pf](https://irc.w3.org/?channels=wot-pf) / [We
+ bEx](https://lists.w3.org/Archives/Member/member-wot-ig/2022Mar/0002.html)
+STATUS:CONFIRMED
+CREATED:20220309T152539Z
+LAST-MODIFIED:20220315T142034Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220316T090000
+END:VEVENT
+BEGIN:VEVENT
+UID:6c159b5a-da9c-4820-b8c3-e3a25b4b93b6
+DTSTAMP:20220510T113009Z
+SUMMARY:WoT Editors
+DTSTART;TZID=America/New_York:20220322T060000
+DTEND;TZID=America/New_York:20220322T070000
+DESCRIPTION:https://www.w3.org/events/meetings/6c159b5a-da9c-4820-b8c3-e3a2
+ 5b4b93b6\n\nTo discuss alignment of documents: terminology\, scheduling\, 
+ topics\, etc.\nFor Editors of all documents\, both normative and informati
+ ve.
+STATUS:CONFIRMED
+CREATED:20220315T143258Z
+LAST-MODIFIED:20220510T113009Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RRULE:FREQ=WEEKLY;UNTIL=20220503T100000Z;INTERVAL=1;BYDAY=TU;WKST=MO
+RELATED-TO:9f571314-f7de-494d-8e93-0705fc6fc9f1
+END:VEVENT
+BEGIN:VEVENT
+UID:6c159b5a-da9c-4820-b8c3-e3a25b4b93b6
+DTSTAMP:20220330T130537Z
+SUMMARY:WoT Editors
+DTSTART;TZID=America/New_York:20220405T060000
+DTEND;TZID=America/New_York:20220405T070000
+DESCRIPTION:https://www.w3.org/events/meetings/6c159b5a-da9c-4820-b8c3-e3a2
+ 5b4b93b6/20220405T060000\n\nTo discuss alignment of documents: terminology
+ \, scheduling\, topics\, etc.\nFor Editors of all documents\, both normati
+ ve and informative.
+STATUS:CANCELLED
+CREATED:20220330T130535Z
+LAST-MODIFIED:20220330T130537Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220405T060000
+END:VEVENT
+BEGIN:VEVENT
+UID:6c159b5a-da9c-4820-b8c3-e3a25b4b93b6
+DTSTAMP:20220413T100859Z
+SUMMARY:WoT Editors
+DTSTART;TZID=America/New_York:20220419T060000
+DTEND;TZID=America/New_York:20220419T070000
+DESCRIPTION:https://www.w3.org/events/meetings/6c159b5a-da9c-4820-b8c3-e3a2
+ 5b4b93b6/20220419T060000\n\nTo discuss alignment of documents: terminology
+ \, scheduling\, topics\, etc.\nFor Editors of all documents\, both normati
+ ve and informative.
+STATUS:CANCELLED
+CREATED:20220413T100858Z
+LAST-MODIFIED:20220413T100859Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220419T060000
+END:VEVENT
+BEGIN:VEVENT
+UID:9f571314-f7de-494d-8e93-0705fc6fc9f1
+DTSTAMP:20220511T100304Z
+SUMMARY:WoT Editors
+DTSTART;TZID=America/New_York:20220510T080000
+DTEND;TZID=America/New_York:20220510T090000
+DESCRIPTION:https://www.w3.org/events/meetings/9f571314-f7de-494d-8e93-0705
+ fc6fc9f1\n\nTo discuss alignment of documents: terminology\, scheduling\, 
+ topics\, etc.\nFor Editors of all documents\, both normative and informati
+ ve.\nNow biweekly\, alternating with Use Cases.
+STATUS:CONFIRMED
+CREATED:20220510T113006Z
+LAST-MODIFIED:20220511T100304Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RELATED-TO:6c159b5a-da9c-4820-b8c3-e3a25b4b93b6
+RELATED-TO:3e99feab-48ed-4f1e-a632-2b94844400b8
+RRULE:FREQ=WEEKLY;UNTIL=20220510T120000Z;INTERVAL=2;BYDAY=TU;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:3e99feab-48ed-4f1e-a632-2b94844400b8
+DTSTAMP:20230201T173029Z
+SUMMARY:WoT Editors
+DTSTART;TZID=America/New_York:20220524T080000
+DTEND;TZID=America/New_York:20220524T090000
+DESCRIPTION:https://www.w3.org/events/meetings/3e99feab-48ed-4f1e-a632-2b94
+ 844400b8\n\nTo discuss alignment of documents: terminology\, scheduling\, 
+ topics\, etc.\nFor Editors of all documents\, both normative and informati
+ ve.\nNow biweekly\, alternating with Use Cases.
+STATUS:CANCELLED
+CREATED:20220511T100302Z
+LAST-MODIFIED:20230201T173029Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RELATED-TO:9f571314-f7de-494d-8e93-0705fc6fc9f1
+RELATED-TO:aeb798f4-8484-4d70-9d4b-cf292ea74899
+RRULE:FREQ=WEEKLY;UNTIL=20230131T130000Z;INTERVAL=2;BYDAY=TU;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:aeb798f4-8484-4d70-9d4b-cf292ea74899
+DTSTAMP:20230201T173028Z
+SUMMARY:WoT Editors
+DTSTART;TZID=America/New_York:20230131T080000
+DTEND;TZID=America/New_York:20230131T090000
+DESCRIPTION:https://www.w3.org/events/meetings/aeb798f4-8484-4d70-9d4b-cf29
+ 2ea74899\n\nTo discuss alignment of documents: terminology\, scheduling\, 
+ topics\, etc.\nFor Editors of all documents\, both normative and informati
+ ve.\nNow biweekly\, alternating with Use Cases.
+STATUS:CANCELLED
+CREATED:20230201T173027Z
+LAST-MODIFIED:20230201T173028Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+END:VEVENT
+BEGIN:VEVENT
+UID:91918c83-c7ef-47bb-9373-ffe1f00ec354
+DTSTAMP:20220719T102926Z
+SUMMARY:WoT Chairs
+DTSTART;TZID=America/New_York:20220323T060000
+DTEND;TZID=America/New_York:20220323T070000
+DESCRIPTION:https://www.w3.org/events/meetings/91918c83-c7ef-47bb-9373-ffe1
+ f00ec354\n\nChairs call\, typically to finalize agenda prior to main call.
+    Just IG/WG/CG chairs and W3C staff\, with the occasional guest.
+STATUS:CONFIRMED
+CREATED:20220315T143455Z
+LAST-MODIFIED:20220719T102926Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Comm
+ unity Group:mailto:public-web-of-things@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RRULE:FREQ=WEEKLY;UNTIL=20220713T100000Z;INTERVAL=1;BYDAY=WE;WKST=MO
+RELATED-TO:266caf8b-597e-456a-9e2b-625ce458ed86
+END:VEVENT
+BEGIN:VEVENT
+UID:266caf8b-597e-456a-9e2b-625ce458ed86
+DTSTAMP:20230201T170237Z
+SUMMARY:WoT Chairs
+DTSTART;TZID=America/New_York:20220720T060000
+DTEND;TZID=America/New_York:20220720T070000
+DESCRIPTION:https://www.w3.org/events/meetings/266caf8b-597e-456a-9e2b-625c
+ e458ed86\n\nChairs call\, typically to finalize agenda prior to main call.
+    Just IG/WG/CG chairs and W3C staff\, with the occasional guest.
+STATUS:CONFIRMED
+CREATED:20220719T102923Z
+LAST-MODIFIED:20230201T170237Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RELATED-TO:91918c83-c7ef-47bb-9373-ffe1f00ec354
+RELATED-TO:763ee682-ba97-480b-9d68-8be75f4e013b
+RRULE:FREQ=WEEKLY;UNTIL=20230201T110000Z;INTERVAL=1;BYDAY=WE;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:266caf8b-597e-456a-9e2b-625ce458ed86
+DTSTAMP:20220831T161956Z
+SUMMARY:WoT Chairs
+DTSTART;TZID=America/New_York:20220914T060000
+DTEND;TZID=America/New_York:20220914T070000
+DESCRIPTION:https://www.w3.org/events/meetings/266caf8b-597e-456a-9e2b-625c
+ e458ed86/20220914T060000\n\nChairs call\, typically to finalize agenda pri
+ or to main call.   Just IG/WG/CG chairs and W3C staff\, with the occasiona
+ l guest.
+STATUS:CANCELLED
+CREATED:20220831T161955Z
+LAST-MODIFIED:20220831T161956Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=America/New_York:20220914T060000
+END:VEVENT
+BEGIN:VEVENT
+UID:763ee682-ba97-480b-9d68-8be75f4e013b
+DTSTAMP:20230530T121602Z
+SUMMARY:WoT Chairs
+DTSTART;TZID=America/New_York:20230208T060000
+DTEND;TZID=America/New_York:20230208T070000
+DESCRIPTION:https://www.w3.org/events/meetings/763ee682-ba97-480b-9d68-8be7
+ 5f4e013b\n\nChairs call\, typically to finalize agenda prior to main call.
+    Just IG/WG/CG chairs and W3C staff\, with the occasional guest.
+STATUS:CONFIRMED
+CREATED:20230201T170235Z
+LAST-MODIFIED:20230530T121602Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RELATED-TO:266caf8b-597e-456a-9e2b-625ce458ed86
+RELATED-TO:7e46d943-8851-4209-854e-73ecc66065f9
+RRULE:FREQ=WEEKLY;UNTIL=20230524T100000Z;INTERVAL=1;BYDAY=WE;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:7e46d943-8851-4209-854e-73ecc66065f9
+DTSTAMP:20230530T121602Z
+SUMMARY:WoT Chairs - TEMPORARILY SUSPENDED
+DTSTART;TZID=America/New_York:20230531T060000
+DTEND;TZID=America/New_York:20230531T070000
+DESCRIPTION:https://www.w3.org/events/meetings/7e46d943-8851-4209-854e-73ec
+ c66065f9\n\nTEMPORARILY SUSPENDED - Looking for a new slot\n\nChairs call\
+ , typically to finalize agenda prior to main call.   Just IG/WG/CG chairs 
+ and W3C staff\, with the occasional guest.
+STATUS:CONFIRMED
+CREATED:20230530T121602Z
+LAST-MODIFIED:20230530T121602Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+RELATED-TO:763ee682-ba97-480b-9d68-8be75f4e013b
+RRULE:FREQ=WEEKLY;UNTIL=20230801T100000Z;INTERVAL=1;BYDAY=WE;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:963d26f3-46dd-49b5-884b-a335418fc9e6
+DTSTAMP:20220330T130510Z
+SUMMARY:WoT Liaisons
+DTSTART;TZID=America/New_York:20220405T060000
+DTEND;TZID=America/New_York:20220405T070000
+DESCRIPTION:https://www.w3.org/events/meetings/963d26f3-46dd-49b5-884b-a335
+ 418fc9e6\n\nSpecial call to discuss liaisons\, in particular with OPC-UA. 
+  Replaces Editor's call this week.
+STATUS:CONFIRMED
+CREATED:20220330T130342Z
+LAST-MODIFIED:20220330T130510Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+END:VEVENT
+BEGIN:VEVENT
+UID:2e4d1489-61bb-4fc9-b180-36525bc6aabc
+DTSTAMP:20220601T142758Z
+SUMMARY:WoT DTDL Overview
+DTSTART;TZID=America/New_York:20220621T080000
+DTEND;TZID=America/New_York:20220621T090000
+DESCRIPTION:https://www.w3.org/events/meetings/2e4d1489-61bb-4fc9-b180-3652
+ 5bc6aabc\n\nSpecial Call\, to be held during Use Case/Editor's Call slot. 
+  To discuss alignment between WoT TD and Microsoft's DTDL\, starting with 
+ an in-depth review of DTDL's specification\, goals\, and capabilities.
+STATUS:CONFIRMED
+CREATED:20220525T105930Z
+LAST-MODIFIED:20220601T142758Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+END:VEVENT
+BEGIN:VEVENT
+UID:62cec435-c0d0-428e-b20a-32140412e6e7
+DTSTAMP:20220601T141928Z
+SUMMARY:WoT Testfest Day 1
+DTSTART;TZID=America/New_York:20220606T080000
+DTEND;TZID=America/New_York:20220606T090000
+DESCRIPTION:https://www.w3.org/events/meetings/62cec435-c0d0-428e-b20a-3214
+ 0412e6e7\n\nSynchronize testing activities.  Focus on Discovery and TDs.
+STATUS:CONFIRMED
+CREATED:20220601T101306Z
+LAST-MODIFIED:20220601T141928Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+END:VEVENT
+BEGIN:VEVENT
+UID:4cb73531-f0ac-4982-ae83-5095a2433a70
+DTSTAMP:20220601T142020Z
+SUMMARY:WoT Testfest Day 3
+DTSTART;TZID=America/New_York:20220608T070000
+DTEND;TZID=America/New_York:20220608T080000
+DESCRIPTION:https://www.w3.org/events/meetings/4cb73531-f0ac-4982-ae83-5095
+ a2433a70\n\nSynchronize testing activities. Focus on Discovery and TDs.
+STATUS:CONFIRMED
+CREATED:20220601T101719Z
+LAST-MODIFIED:20220601T142020Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+END:VEVENT
+BEGIN:VEVENT
+UID:f459a6bd-6803-4a9d-90ec-a38d71efe43e
+DTSTAMP:20220601T141953Z
+SUMMARY:WoT Testfest Day 2
+DTSTART;TZID=America/New_York:20220607T080000
+DTEND;TZID=America/New_York:20220607T090000
+DESCRIPTION:https://www.w3.org/events/meetings/f459a6bd-6803-4a9d-90ec-a38d
+ 71efe43e\n\nSynchronize testing activities. Focus on Discovery and TDs.
+STATUS:CONFIRMED
+CREATED:20220601T101944Z
+LAST-MODIFIED:20220601T141953Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+END:VEVENT
+BEGIN:VEVENT
+UID:780e1133-20e0-4fde-b019-5757ddae3100
+DTSTAMP:20220601T142042Z
+SUMMARY:WoT Testfest Day 4
+DTSTART;TZID=America/New_York:20220609T100000
+DTEND;TZID=America/New_York:20220609T110000
+DESCRIPTION:https://www.w3.org/events/meetings/780e1133-20e0-4fde-b019-5757
+ ddae3100\n\nSynchronize testing activities. Focus on Discovery and TDs.
+STATUS:CONFIRMED
+CREATED:20220601T102202Z
+LAST-MODIFIED:20220601T142042Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+END:VEVENT
+BEGIN:VEVENT
+UID:6ce7c447-441e-4884-9700-bdf22a39afd4
+DTSTAMP:20220601T142106Z
+SUMMARY:WoT Testfest Day 5
+DTSTART;TZID=America/New_York:20220610T100000
+DTEND;TZID=America/New_York:20220610T110000
+DESCRIPTION:https://www.w3.org/events/meetings/6ce7c447-441e-4884-9700-bdf2
+ 2a39afd4\n\nSynchronize testing activities. Focus on Discovery and TDs.
+STATUS:CONFIRMED
+CREATED:20220601T102303Z
+LAST-MODIFIED:20220601T142106Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+END:VEVENT
+BEGIN:VEVENT
+UID:103c9ea5-c6da-4e56-b78c-12eef5ad3edb
+DTSTAMP:20220912T143348Z
+SUMMARY:Web of Things Working Group and Web of Things Interest Group
+DTSTART;TZID=America/Vancouver:20220912T080000
+DTEND;TZID=America/Vancouver:20220912T100000
+DESCRIPTION:https://www.w3.org/events/meetings/103c9ea5-c6da-4e56-b78c-12ee
+ f5ad3edb\n\nThe agenda for this meeting is here: https://www.w3.org/WoT/IG
+ /wiki/F2F_meeting\,_September_2022#Monday.2C_September_12\n\nAs this is on
+ ly a 2h meeting no break will be scheduled.
+STATUS:CONFIRMED
+CREATED:20220610T041309Z
+LAST-MODIFIED:20220912T143348Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:Port Hardy - North Tower 4th floor
+CATEGORIES:TPAC 2022,Group Meetings
+END:VEVENT
+BEGIN:VEVENT
+UID:ce176ee4-0fcb-4737-a858-a2d243aab20a
+DTSTAMP:20220913T085452Z
+SUMMARY:Web of Things Working Group and Web of Things Interest Group
+DTSTART;TZID=America/Vancouver:20220914T080000
+DTEND;TZID=America/Vancouver:20220914T100000
+DESCRIPTION:https://www.w3.org/events/meetings/ce176ee4-0fcb-4737-a858-a2d2
+ 43aab20a\n\nThe agenda for this meeting is here: https://www.w3.org/WoT/IG
+ /wiki/F2F_meeting\,_September_2022#Wednesday.2C_September_14\n\nAs this is
+  only a 2h meeting no break will be scheduled.
+STATUS:CONFIRMED
+CREATED:20220610T052043Z
+LAST-MODIFIED:20220913T085452Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:Orca - 3rd floor Concourse
+CATEGORIES:TPAC 2022,Group Meetings
+END:VEVENT
+BEGIN:VEVENT
+UID:12b636a2-d435-4752-bd77-6fde10d1b74e
+DTSTAMP:20220630T090503Z
+SUMMARY:Pre-Meeting OPC UA / W3C WoT Joint Activity
+DTSTART;TZID=Europe/Berlin:20220701T140000
+DTEND;TZID=Europe/Berlin:20220701T150000
+DESCRIPTION:https://www.w3.org/events/meetings/12b636a2-d435-4752-bd77-6fde
+ 10d1b74e\n\nFirst preliminary meeting to bring together the interested par
+ ties\, to explain the exact plans\, the current status of the formal coope
+ ration between OPCF and W3C\, and the next steps.\n\nAgenda\n\n1. Welcome 
+ & Scope of the Meeting \n\n2. Short round of introduction\n\n3. Proposed I
+ dea: OPC UA Binding for Web of Things\n\n4. Current status of collaboratio
+ n\n\n5. Proposed next steps\n\n6. Questions\n\nJoining Instructions: https
+ ://mit.webex.com/mit/j.php?MTID=m7ad4daf941a496ab443e073f489b1bf1\n\nChat\
+ n\nhttps://irc.w3.org/?channels=wot
+STATUS:CONFIRMED
+CREATED:20220622T101322Z
+LAST-MODIFIED:20220630T090503Z
+SEQUENCE:4
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+END:VEVENT
+BEGIN:VEVENT
+UID:15384878-62b8-465d-acde-6c34c671488d
+DTSTAMP:20220719T102500Z
+SUMMARY:WoT DTDL
+DTSTART;TZID=America/New_York:20220719T080000
+DTEND;TZID=America/New_York:20220719T090000
+DESCRIPTION:https://www.w3.org/events/meetings/15384878-62b8-465d-acde-6c34
+ c671488d\n\nSpecial Call\, to be held during Use Case/Editor's Call slot. 
+ To discuss alignment between WoT TD and Microsoft's DTDL.
+STATUS:CONFIRMED
+CREATED:20220719T102049Z
+LAST-MODIFIED:20220719T102500Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+END:VEVENT
+BEGIN:VEVENT
+UID:464fe807-f937-4f18-abcb-7bfbd6eea591
+DTSTAMP:20220720T143522Z
+SUMMARY:WoT Testfest - 1
+DTSTART;TZID=America/New_York:20220725T080000
+DTEND;TZID=America/New_York:20220725T090000
+DESCRIPTION:https://www.w3.org/events/meetings/464fe807-f937-4f18-abcb-7bfb
+ d6eea591\n\nTestfest synchronization call.\nSee https://github.com/w3c/wot
+ -testing/tree/main/events/2022.07.Online
+STATUS:CONFIRMED
+CREATED:20220720T111005Z
+LAST-MODIFIED:20220720T143522Z
+SEQUENCE:5
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+END:VEVENT
+BEGIN:VEVENT
+UID:80976a91-be64-40ba-933e-c959081810a6
+DTSTAMP:20220720T143546Z
+SUMMARY:WoT Testfest -  2
+DTSTART;TZID=America/New_York:20220726T080000
+DTEND;TZID=America/New_York:20220726T090000
+DESCRIPTION:https://www.w3.org/events/meetings/80976a91-be64-40ba-933e-c959
+ 081810a6\n\nTestfest synchronization call.\nSee https://github.com/w3c/wot
+ -testing/tree/main/events/2022.07.Online
+STATUS:CONFIRMED
+CREATED:20220720T113436Z
+LAST-MODIFIED:20220720T143546Z
+SEQUENCE:4
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+END:VEVENT
+BEGIN:VEVENT
+UID:c06b4d35-702a-46c9-9079-3070412e2fbe
+DTSTAMP:20220720T143607Z
+SUMMARY:WoT Testfest - 3
+DTSTART;TZID=America/New_York:20220727T090000
+DTEND;TZID=America/New_York:20220727T100000
+DESCRIPTION:https://www.w3.org/events/meetings/c06b4d35-702a-46c9-9079-3070
+ 412e2fbe\n\nTestfest synchronization call.\nSee https://github.com/w3c/wot
+ -testing/tree/main/events/2022.07.Online
+STATUS:CONFIRMED
+CREATED:20220720T114033Z
+LAST-MODIFIED:20220720T143607Z
+SEQUENCE:4
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+END:VEVENT
+BEGIN:VEVENT
+UID:77c7a762-342b-4485-9b85-3166b7712ff0
+DTSTAMP:20220720T143631Z
+SUMMARY:WoT Testfest - 4
+DTSTART;TZID=America/New_York:20220728T080000
+DTEND;TZID=America/New_York:20220728T090000
+DESCRIPTION:https://www.w3.org/events/meetings/77c7a762-342b-4485-9b85-3166
+ b7712ff0\n\nTestfest synchronization call.\nSee https://github.com/w3c/wot
+ -testing/tree/main/events/2022.07.Online
+STATUS:CONFIRMED
+CREATED:20220720T114336Z
+LAST-MODIFIED:20220720T143631Z
+SEQUENCE:4
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+END:VEVENT
+BEGIN:VEVENT
+UID:43a2fa9c-2b61-4440-9299-ee143252dc50
+DTSTAMP:20220720T143656Z
+SUMMARY:WoT Testfest - 5
+DTSTART;TZID=America/New_York:20220729T080000
+DTEND;TZID=America/New_York:20220729T090000
+DESCRIPTION:https://www.w3.org/events/meetings/43a2fa9c-2b61-4440-9299-ee14
+ 3252dc50\n\nTestfest synchronization call.\nSee https://github.com/w3c/wot
+ -testing/tree/main/events/2022.07.Online
+STATUS:CONFIRMED
+CREATED:20220720T114755Z
+LAST-MODIFIED:20220720T143656Z
+SEQUENCE:4
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+END:VEVENT
+BEGIN:VEVENT
+UID:f645fbac-6b0a-42c1-aa6c-4a5a51ddf2c3
+DTSTAMP:20220727T111326Z
+SUMMARY:OPC UA / W3C WoT - Technical Discussion
+DTSTART;TZID=Europe/Berlin:20220728T130000
+DTEND;TZID=Europe/Berlin:20220728T140000
+DESCRIPTION:https://www.w3.org/events/meetings/f645fbac-6b0a-42c1-aa6c-4a5a
+ 51ddf2c3\n\ntbd
+STATUS:CANCELLED
+CREATED:20220721T122204Z
+LAST-MODIFIED:20220727T111326Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+LOCATION:tbd
+END:VEVENT
+BEGIN:VEVENT
+UID:b32cc6be-598a-401d-81c8-36c2309f8692
+DTSTAMP:20220913T145423Z
+SUMMARY:Web of Things Community Group- Online meeting only
+DTSTART;TZID=America/Vancouver:20220913T080000
+DTEND;TZID=America/Vancouver:20220913T090000
+DESCRIPTION:https://www.w3.org/events/meetings/b32cc6be-598a-401d-81c8-36c2
+ 309f8692\n\n\n\nAgenda\n\n- Introduction to the WoT CG\n- Explaining the c
+ urrent roles of WG\, IG and CG.\n- Discussion on how to work together\n- N
+ ext CG events\n- Wrap-up and conclusion\n\nGiven that we have only 1 hour 
+ and it is an online meeting\, no breaks are planned
+STATUS:CONFIRMED
+CREATED:20220804T054327Z
+LAST-MODIFIED:20220913T145423Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Comm
+ unity Group:mailto:public-web-of-things@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:Online
+CATEGORIES:TPAC 2022,Group Meetings
+END:VEVENT
+BEGIN:VEVENT
+UID:0d498d94-04b1-471b-9bd3-fc614db62257
+DTSTAMP:20220915T091503Z
+SUMMARY:OPC UA / W3C WoT - Technical Discussion
+DTSTART;TZID=Europe/Berlin:20220915T140000
+DTEND;TZID=Europe/Berlin:20220915T150000
+DESCRIPTION:https://www.w3.org/events/meetings/0d498d94-04b1-471b-9bd3-fc61
+ 4db62257\n\nDraft agenda:\n- Welcome and meeting logistics\n- Short round 
+ of introductions of the new participants \n- discussion about  https://git
+ hub.com/w3c/wot/blob/main/liaisons/opcf/tech_reqs.md\n- organize regular O
+ PC UA / WoT technical meetings\n\nJoining Instructions: https://mit.webex.
+ com/wbxmjs/joinservice/sites/mit/meeting/download/826a7b59af8f434d85a9f068
+ 0500dca4?siteurl=mit&MTID=mbbd7c51c711014c2239da5a70756fd31
+STATUS:CONFIRMED
+CREATED:20220819T173425Z
+LAST-MODIFIED:20220915T091503Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+END:VEVENT
+BEGIN:VEVENT
+UID:4d9ed177-536f-4482-bc77-0a238079745f
+DTSTAMP:20220823T133128Z
+SUMMARY:WoT Discovery (Uncanceled)
+DTSTART;TZID=America/New_York:20220829T100000
+DTEND;TZID=America/New_York:20220829T110000
+DESCRIPTION:https://www.w3.org/events/meetings/4d9ed177-536f-4482-bc77-0a23
+ 8079745f\n\nThe [WoT Discovery task force](https://www.w3.org/WoT/IG/wiki/
+ WG_WoT_Discovery_WebConf) is responsible for defining a distribution mecha
+ nism for WoT Thing Descriptions that can be used to facilitate access to W
+ oT Things and services while supporting security and privacy.\n\n[IRC: #wo
+ t-discovery](https://irc.w3.org/?channels=wot-discovery) / [WebEx](https:/
+ /lists.w3.org/Archives/Member/member-wot-wg/2020Feb/0009.html)
+STATUS:CONFIRMED
+CREATED:20220823T133043Z
+LAST-MODIFIED:20220823T133128Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+END:VEVENT
+BEGIN:VEVENT
+UID:e2d65f8d-1fb6-4026-8c5f-cb1e458361a1
+DTSTAMP:20220830T133255Z
+SUMMARY:WoT Profiles (NEW)
+DTSTART;TZID=America/New_York:20220831T070000
+DTEND;TZID=America/New_York:20220831T080000
+DESCRIPTION:https://www.w3.org/events/meetings/e2d65f8d-1fb6-4026-8c5f-cb1e
+ 458361a1\n\n(note: this is a new entry\, replacing the cancelled event)\n\
+ nThe [WoT Architecture task force](https://www.w3.org/WoT/IG/wiki/WG_WoT_A
+ rchitecture_WebConf) is responsible for both the abstract architecture and
+  interoperability profiles for the Web of Things.\n\n[IRC: #wot-profile](h
+ ttps://irc.w3.org/#channels=wot-profile) / [WebEx](https://lists.w3.org/Ar
+ chives/Member/member-wot-wg/2022Jan/0006.html)
+STATUS:CONFIRMED
+CREATED:20220830T132740Z
+LAST-MODIFIED:20220830T133255Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+END:VEVENT
+BEGIN:VEVENT
+UID:69ca30d9-95d8-4f1b-bb03-bcc533380d36
+DTSTAMP:20220905T154245Z
+SUMMARY:WoT Pre-TPAC Session 1
+DTSTART;TZID=America/New_York:20220906T080000
+DTEND;TZID=America/New_York:20220906T100000
+DESCRIPTION:https://www.w3.org/events/meetings/69ca30d9-95d8-4f1b-bb03-bcc5
+ 33380d36\n\nhttps://www.w3.org/WoT/IG/wiki/F2F_meeting\,_September_2022#Tu
+ esday.2C_September_6\n\nAgenda: https://www.w3.org/WoT/IG/wiki/F2F_meeting
+ \,_September_2022#Tuesday.2C_September_6
+STATUS:CONFIRMED
+CREATED:20220905T133200Z
+LAST-MODIFIED:20220905T154245Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:Zoom
+END:VEVENT
+BEGIN:VEVENT
+UID:d2d71902-7e45-4e43-914f-8e349879c818
+DTSTAMP:20220905T154320Z
+SUMMARY:WoT Pre-TPAC Session 2
+DTSTART;TZID=America/New_York:20220907T080000
+DTEND;TZID=America/New_York:20220907T100000
+DESCRIPTION:https://www.w3.org/events/meetings/d2d71902-7e45-4e43-914f-8e34
+ 9879c818\n\nhttps://www.w3.org/WoT/IG/wiki/F2F_meeting\,_September_2022#We
+ dnesday.2C_September_7\n\nAgenda: https://www.w3.org/WoT/IG/wiki/F2F_meeti
+ ng\,_September_2022#Wednesday.2C_September_7
+STATUS:CONFIRMED
+CREATED:20220905T133528Z
+LAST-MODIFIED:20220905T154320Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:Zoom
+END:VEVENT
+BEGIN:VEVENT
+UID:a8ec1457-03e8-4306-9b00-c77d570727a8
+DTSTAMP:20220920T011920Z
+SUMMARY:WoT Post-TPAC Session 1
+DTSTART;TZID=America/New_York:20220920T080000
+DTEND;TZID=America/New_York:20220920T100000
+DESCRIPTION:https://www.w3.org/events/meetings/a8ec1457-03e8-4306-9b00-c77d
+ 570727a8\n\nAgenda:  https://www.w3.org/WoT/IG/wiki/F2F_meeting\,_Septembe
+ r_2022#Tuesday.2C_September_20\n\nAgenda: https://www.w3.org/WoT/IG/wiki/F
+ 2F_meeting\,_September_2022#Tuesday.2C_September_20
+STATUS:CANCELLED
+CREATED:20220916T132241Z
+LAST-MODIFIED:20220920T011920Z
+SEQUENCE:5
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+END:VEVENT
+BEGIN:VEVENT
+UID:cee61e93-c69f-4284-872a-7e0555e80c33
+DTSTAMP:20220919T152356Z
+SUMMARY:WoT Post-TPAC Session 2
+DTSTART;TZID=America/New_York:20220921T080000
+DTEND;TZID=America/New_York:20220921T100000
+DESCRIPTION:https://www.w3.org/events/meetings/cee61e93-c69f-4284-872a-7e05
+ 55e80c33\n\nAgenda: https://www.w3.org/WoT/IG/wiki/F2F_meeting\,_September
+ _2022#Wednesday.2C_September_21\n\nAgenda: https://www.w3.org/WoT/IG/wiki/
+ F2F_meeting\,_September_2022#Wednesday.2C_September_21
+STATUS:CONFIRMED
+CREATED:20220916T132754Z
+LAST-MODIFIED:20220919T152356Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+END:VEVENT
+BEGIN:VEVENT
+UID:c171edb0-1fb9-4eb1-92a6-6dd054a97b07
+DTSTAMP:20220919T152443Z
+SUMMARY:WoT Post-TPAC Session 3
+DTSTART;TZID=America/New_York:20220922T080000
+DTEND;TZID=America/New_York:20220922T100000
+DESCRIPTION:https://www.w3.org/events/meetings/c171edb0-1fb9-4eb1-92a6-6dd0
+ 54a97b07\n\nAgenda: https://www.w3.org/WoT/IG/wiki/F2F_meeting\,_September
+ _2022#Thursday.2C_September_22\n\nAgenda: https://www.w3.org/WoT/IG/wiki/F
+ 2F_meeting\,_September_2022#Thursday.2C_September_22
+STATUS:CONFIRMED
+CREATED:20220916T133015Z
+LAST-MODIFIED:20220919T152443Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+END:VEVENT
+BEGIN:VEVENT
+UID:58647a9f-f006-4ec5-a7f4-de6aefd37f35
+DTSTAMP:20221003T111148Z
+SUMMARY:WoT Testfest
+DTSTART;TZID=America/New_York:20221003T080000
+DTEND;TZID=America/New_York:20221003T090000
+DESCRIPTION:https://www.w3.org/events/meetings/58647a9f-f006-4ec5-a7f4-de6a
+ efd37f35\n\nWeb of Things testing\, with a focus on Architecture and Profi
+ les\, but also finishing up Discovery and Thing Description.\n\nAgenda: ht
+ tps://github.com/w3c/wot-testing/tree/main/events/2022.09.Online
+STATUS:CONFIRMED
+CREATED:20221003T111119Z
+LAST-MODIFIED:20221003T111148Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+END:VEVENT
+BEGIN:VEVENT
+UID:1e06ad81-e31c-4dfd-bcb7-b8f0851ddb4c
+DTSTAMP:20221003T111905Z
+SUMMARY:WoT Testfest
+DTSTART;TZID=America/New_York:20221004T080000
+DTEND;TZID=America/New_York:20221004T090000
+DESCRIPTION:https://www.w3.org/events/meetings/1e06ad81-e31c-4dfd-bcb7-b8f0
+ 851ddb4c\n\nWeb of Things testing\, with a focus on Architecture and Profi
+ les\, but also finishing up Discovery and Thing Description.\n\nAgenda: ht
+ tps://github.com/w3c/wot-testing/tree/main/events/2022.09.Online
+STATUS:CONFIRMED
+CREATED:20221003T111904Z
+LAST-MODIFIED:20221003T111905Z
+SEQUENCE:0
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+END:VEVENT
+BEGIN:VEVENT
+UID:7cd698b0-62fa-4abd-a83d-5383ae3d9380
+DTSTAMP:20221003T112332Z
+SUMMARY:WoT Testfest
+DTSTART;TZID=America/New_York:20221005T070000
+DTEND;TZID=America/New_York:20221005T080000
+DESCRIPTION:https://www.w3.org/events/meetings/7cd698b0-62fa-4abd-a83d-5383
+ ae3d9380\n\nWeb of Things testing\, with a focus on Architecture and Profi
+ les\, but also finishing up Discovery and Thing Description.\n\nAgenda: ht
+ tps://github.com/w3c/wot-testing/tree/main/events/2022.09.Online
+STATUS:CONFIRMED
+CREATED:20221003T112215Z
+LAST-MODIFIED:20221003T112332Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+END:VEVENT
+BEGIN:VEVENT
+UID:a5f4ace9-9c8b-462c-8fd1-be5f4e496a52
+DTSTAMP:20221003T112824Z
+SUMMARY:WoT Testfest
+DTSTART;TZID=America/New_York:20221006T100000
+DTEND;TZID=America/New_York:20221006T110000
+DESCRIPTION:https://www.w3.org/events/meetings/a5f4ace9-9c8b-462c-8fd1-be5f
+ 4e496a52\n\nWeb of Things testing\, with a focus on Architecture and Profi
+ les\, but also finishing up Discovery and Thing Description.\n\nAgenda: ht
+ tps://github.com/w3c/wot-testing/tree/main/events/2022.09.Online
+STATUS:CONFIRMED
+CREATED:20221003T112757Z
+LAST-MODIFIED:20221003T112824Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+END:VEVENT
+BEGIN:VEVENT
+UID:4aa90fac-954b-4113-aab7-6cd6f054d888
+DTSTAMP:20221003T113052Z
+SUMMARY:WoT Testfest
+DTSTART;TZID=America/New_York:20221007T100000
+DTEND;TZID=America/New_York:20221007T110000
+DESCRIPTION:https://www.w3.org/events/meetings/4aa90fac-954b-4113-aab7-6cd6
+ f054d888\n\nWeb of Things testing\, with a focus on Architecture and Profi
+ les\, but also finishing up Discovery and Thing Description.\n\nAgenda: ht
+ tps://github.com/w3c/wot-testing/tree/main/events/2022.09.Online
+STATUS:CONFIRMED
+CREATED:20221003T113051Z
+LAST-MODIFIED:20221003T113052Z
+SEQUENCE:0
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+END:VEVENT
+BEGIN:VEVENT
+UID:949c91b1-580b-48bd-9530-82b03ddfbc81
+DTSTAMP:20221207T153749Z
+SUMMARY:WoT Use Cases
+DTSTART;TZID=America/New_York:20221220T080000
+DTEND;TZID=America/New_York:20221220T090000
+DESCRIPTION:https://www.w3.org/events/meetings/949c91b1-580b-48bd-9530-82b0
+ 3ddfbc81\n\nGather requirements for next WG charter draft.\n\nTuesday\, De
+ c 13\, 2022 8:00 am | 1 hour | (UTC-05:00) Eastern Time (US & Canada)\n\nS
+ ee also:\nhttps://www.timeanddate.com/worldclock/converter.html?iso=202212
+ 13T130000&p1=137&p2=43&p3=tz_at&p4=1440&p5=136&p6=195&p7=101&p8=33&p9=236&
+ p10=248\n\nAgenda: https://www.w3.org/WoT/IG/wiki/IG_UseCase_WebConf
+STATUS:CONFIRMED
+CREATED:20221207T153701Z
+LAST-MODIFIED:20221207T153749Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+END:VEVENT
+BEGIN:VEVENT
+UID:24ba50db-a38d-4ad9-81fc-8b9ebec98e6a
+DTSTAMP:20221207T160034Z
+SUMMARY:WoT Testfest - 1
+DTSTART;TZID=America/New_York:20221212T080000
+DTEND;TZID=America/New_York:20221212T090000
+DESCRIPTION:https://www.w3.org/events/meetings/24ba50db-a38d-4ad9-81fc-8b9e
+ bec98e6a\n\nSync meeting for Dec 2022 testfest.\n\nMonday\, Dec. 12: 8am E
+ astern\n  See also: https://www.timeanddate.com/worldclock/converter.html?
+ iso=20221212T130000&p1=137&p2=43&p3=tz_at&p4=1440&p5=136&p6=195&p7=101&p8=
+ 33&p9=236&p10=248\n\nAgenda: https://github.com/w3c/wot-testing/blob/main/
+ events/2022.12.Online/README.md
+STATUS:CONFIRMED
+CREATED:20221207T154508Z
+LAST-MODIFIED:20221207T160034Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+END:VEVENT
+BEGIN:VEVENT
+UID:d6c87603-69f5-4234-8156-0482f04aed01
+DTSTAMP:20221207T155640Z
+SUMMARY:WoT Testfest - 2
+DTSTART;TZID=America/New_York:20221213T080000
+DTEND;TZID=America/New_York:20221213T090000
+DESCRIPTION:https://www.w3.org/events/meetings/d6c87603-69f5-4234-8156-0482
+ f04aed01\n\nSync meeting for Dec 2022 testfest.\n\nTuesday\, Dec. 13: 8am 
+ Eastern\nhttps://www.timeanddate.com/worldclock/converter.html?iso=2022121
+ 3T130000&p1=137&p2=43&p3=tz_at&p4=1440&p5=136&p6=195&p7=101&p8=33&p9=236&p
+ 10=248\n\nAgenda: https://github.com/w3c/wot-testing/blob/main/events/2022
+ .12.Online/README.md
+STATUS:CONFIRMED
+CREATED:20221207T154929Z
+LAST-MODIFIED:20221207T155640Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+END:VEVENT
+BEGIN:VEVENT
+UID:6c1490d9-c900-4114-8cf7-75ba490e4c46
+DTSTAMP:20221208T121108Z
+SUMMARY:WoT Testfest -3
+DTSTART;TZID=America/New_York:20221214T090000
+DTEND;TZID=America/New_York:20221214T100000
+DESCRIPTION:https://www.w3.org/events/meetings/6c1490d9-c900-4114-8cf7-75ba
+ 490e4c46\n\nSync meeting for Dec 2022 testfest.\n\nWednesday\, Dec 14: 9am
+  Eastern\n  See also: https://www.timeanddate.com/worldclock/converter.htm
+ l?iso=20221214T140000&p1=137&p2=43&p3=tz_at&p4=1440&p5=136&p6=195&p7=101&p
+ 8=33&p9=236&p10=248\n\nAgenda: https://github.com/w3c/wot-testing/blob/mai
+ n/events/2022.12.Online/README.md
+STATUS:CONFIRMED
+CREATED:20221207T155119Z
+LAST-MODIFIED:20221208T121108Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+END:VEVENT
+BEGIN:VEVENT
+UID:483131a1-33ba-433f-8c99-f7e5981866d1
+DTSTAMP:20221207T155730Z
+SUMMARY:WoT Testfest - 4
+DTSTART;TZID=America/New_York:20221215T100000
+DTEND;TZID=America/New_York:20221215T110000
+DESCRIPTION:https://www.w3.org/events/meetings/483131a1-33ba-433f-8c99-f7e5
+ 981866d1\n\nSync meeting for Dec 2022 testfest.\n\nThursday\, Dec 15: 10am
+  Eastern\n  See also: https://www.timeanddate.com/worldclock/converter.htm
+ l?iso=20221215T150000&p1=137&p2=43&p3=tz_at&p4=1440&p5=136&p6=195&p7=101&p
+ 8=33&p9=236&p10=248\n\nAgenda: https://github.com/w3c/wot-testing/blob/mai
+ n/events/2022.12.Online/README.md
+STATUS:CONFIRMED
+CREATED:20221207T155454Z
+LAST-MODIFIED:20221207T155730Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+END:VEVENT
+BEGIN:VEVENT
+UID:504ef715-9e3b-44a7-b8a5-34eab01da99a
+DTSTAMP:20230111T111915Z
+SUMMARY:WoT Charter
+DTSTART;TZID=America/New_York:20230116T080000
+DTEND;TZID=America/New_York:20230116T100000
+DESCRIPTION:https://www.w3.org/events/meetings/504ef715-9e3b-44a7-b8a5-34ea
+ b01da99a\n\nhttps://www.w3.org/WoT/IG/wiki/Main_WoT_WebConf#Special_Meetin
+ gs_to_Discuss_Next_Charter\n\nSpecial meeting to discuss next WG charter.\
+ nScheduled as a two hour meeting but will be only 1h on Jan 16 and 17.\n\n
+ Agenda: https://www.w3.org/WoT/IG/wiki/Main_WoT_WebConf#Agenda_Day_1_-_Jan
+ _16
+STATUS:CONFIRMED
+CREATED:20230111T111846Z
+LAST-MODIFIED:20230111T111915Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RRULE:FREQ=DAILY;UNTIL=20230119T130000Z;INTERVAL=1;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:8e3e63cf-3c52-40d8-91a4-561d4b6a5f97
+DTSTAMP:20230202T162148Z
+SUMMARY:WoT Architecture
+DTSTART;TZID=Europe/Berlin:20230202T120000
+DTEND;TZID=Europe/Berlin:20230202T130000
+DESCRIPTION:https://www.w3.org/events/meetings/8e3e63cf-3c52-40d8-91a4-561d
+ 4b6a5f97\n\nThe [WoT Architecture task force](https://www.w3.org/WoT/IG/wi
+ ki/WG_WoT_Architecture_WebConf) is responsible for both the abstract archi
+ tecture and interoperability profiles for the Web of Things.\n\n[IRC: #wot
+ -profile](https://irc.w3.org/#channels=wot-profile) / [WebEx](https://list
+ s.w3.org/Archives/Member/member-wot-wg/2022Jan/0006.html)
+STATUS:CONFIRMED
+CREATED:20230130T071403Z
+LAST-MODIFIED:20230202T162148Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+RRULE:FREQ=WEEKLY;UNTIL=20230209T110000Z;INTERVAL=1;BYDAY=TH;WKST=MO
+RELATED-TO:51c221d1-fc1c-411a-a4b5-a4b276916d5f
+END:VEVENT
+BEGIN:VEVENT
+UID:51c221d1-fc1c-411a-a4b5-a4b276916d5f
+DTSTAMP:20230202T162148Z
+SUMMARY:WoT Architecture
+DTSTART;TZID=Europe/Berlin:20230209T120000
+DTEND;TZID=Europe/Berlin:20230209T130000
+DESCRIPTION:https://www.w3.org/events/meetings/51c221d1-fc1c-411a-a4b5-a4b2
+ 76916d5f\n\nThe [WoT Architecture task force](https://www.w3.org/WoT/IG/wi
+ ki/WG_WoT_Architecture_WebConf) is responsible for both the abstract archi
+ tecture and interoperability profiles for the Web of Things.\n\n[IRC: #wot
+ -profile](https://irc.w3.org/#channels=wot-profile) / [WebEx](https://list
+ s.w3.org/Archives/Member/member-wot-wg/2022Jan/0006.html)
+STATUS:CONFIRMED
+CREATED:20230202T162148Z
+LAST-MODIFIED:20230202T162148Z
+SEQUENCE:0
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+END:VEVENT
+BEGIN:VEVENT
+UID:dca3d80c-faed-46b0-85be-d02dcc77aa1d
+DTSTAMP:20230207T130634Z
+SUMMARY:WoT Use Case
+DTSTART;TZID=Europe/Berlin:20230131T140000
+DTEND;TZID=Europe/Berlin:20230131T150000
+DESCRIPTION:https://www.w3.org/events/meetings/dca3d80c-faed-46b0-85be-d02d
+ cc77aa1d\n\nThe [WoT Use Case task force](https://www.w3.org/WoT/IG/wiki/I
+ G_UseCase_WebConf) is responsible for collecting use cases for WoT and ext
+ racting requirements. Use cases can include both specific vertical applica
+ tions as well as relevant horizontal technologies or other horizontal usag
+ e patterns. Guests who are not WoT members but who have an interest in spe
+ cific vertical application domains\, technologies\, or usage patterns are 
+ explicitly invited to engage with this task force to provide input.\n\n[IR
+ C: #wot-uc](https://irc.w3.org/?channels=wot-uc) / [WebEx](https://lists.w
+ 3.org/Archives/Member/member-wot-wg/2021Mar/0044.html)
+STATUS:CONFIRMED
+CREATED:20230130T072057Z
+LAST-MODIFIED:20230207T130634Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+LOCATION:WebEx
+RRULE:FREQ=WEEKLY;UNTIL=20230207T130000Z;INTERVAL=1;BYDAY=TU;WKST=MO
+RELATED-TO:1c392e72-6df9-4c18-b02a-f7f556749763
+END:VEVENT
+BEGIN:VEVENT
+UID:1c392e72-6df9-4c18-b02a-f7f556749763
+DTSTAMP:20230221T130552Z
+SUMMARY:WoT Use Case
+DTSTART;TZID=Europe/Berlin:20230207T140000
+DTEND;TZID=Europe/Berlin:20230207T150000
+DESCRIPTION:https://www.w3.org/events/meetings/1c392e72-6df9-4c18-b02a-f7f5
+ 56749763\n\nThe [WoT Use Case task force](https://www.w3.org/WoT/IG/wiki/I
+ G_UseCase_WebConf) is responsible for collecting use cases for WoT and ext
+ racting requirements. Use cases can include both specific vertical applica
+ tions as well as relevant horizontal technologies or other horizontal usag
+ e patterns. Guests who are not WoT members but who have an interest in spe
+ cific vertical application domains\, technologies\, or usage patterns are 
+ explicitly invited to engage with this task force to provide input.\n\n[IR
+ C: #wot-uc](https://irc.w3.org/?channels=wot-uc) / [WebEx](https://lists.w
+ 3.org/Archives/Member/member-wot-wg/2021Mar/0044.html)
+STATUS:CONFIRMED
+CREATED:20230207T130632Z
+LAST-MODIFIED:20230221T130552Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RELATED-TO:dca3d80c-faed-46b0-85be-d02dcc77aa1d
+RELATED-TO:e62950a1-4c4e-4145-8de4-acdef4c3c448
+RRULE:FREQ=WEEKLY;UNTIL=20230221T130000Z;INTERVAL=1;BYDAY=TU;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:1c392e72-6df9-4c18-b02a-f7f556749763
+DTSTAMP:20230212T225617Z
+SUMMARY:CANCELLED WoT Use Case
+DTSTART;TZID=Europe/Berlin:20230214T140000
+DTEND;TZID=Europe/Berlin:20230214T150000
+DESCRIPTION:https://www.w3.org/events/meetings/1c392e72-6df9-4c18-b02a-f7f5
+ 56749763/20230214T140000\n\nThe [WoT Use Case task force](https://www.w3.o
+ rg/WoT/IG/wiki/IG_UseCase_WebConf) is responsible for collecting use cases
+  for WoT and extracting requirements. Use cases can include both specific 
+ vertical applications as well as relevant horizontal technologies or other
+  horizontal usage patterns. Guests who are not WoT members but who have an
+  interest in specific vertical application domains\, technologies\, or usa
+ ge patterns are explicitly invited to engage with this task force to provi
+ de input.\n\n[IRC: #wot-uc](https://irc.w3.org/?channels=wot-uc) / [WebEx]
+ (https://lists.w3.org/Archives/Member/member-wot-wg/2021Mar/0044.html)
+STATUS:TENTATIVE
+CREATED:20230212T225616Z
+LAST-MODIFIED:20230212T225617Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=Europe/Berlin:20230214T140000
+END:VEVENT
+BEGIN:VEVENT
+UID:e62950a1-4c4e-4145-8de4-acdef4c3c448
+DTSTAMP:20230310T145759Z
+SUMMARY:WoT <strike>Use Case</strike> Charter
+DTSTART;TZID=Europe/Berlin:20230221T140000
+DTEND;TZID=Europe/Berlin:20230221T150000
+DESCRIPTION:https://www.w3.org/events/meetings/e62950a1-4c4e-4145-8de4-acde
+ f4c3c448\n\nNote: this slot will be used instead for additional charter di
+ scussion\, and as such will be a WG\, not an IG call.\n\nThe [WoT Use Case
+  task force](https://www.w3.org/WoT/IG/wiki/IG_UseCase_WebConf) is respons
+ ible for collecting use cases for WoT and extracting requirements. Use cas
+ es can include both specific vertical applications as well as relevant hor
+ izontal technologies or other horizontal usage patterns. Guests who are no
+ t WoT members but who have an interest in specific vertical application do
+ mains\, technologies\, or usage patterns are explicitly invited to engage 
+ with this task force to provide input.\n\n[IRC: #wot-uc](https://irc.w3.or
+ g/?channels=wot-uc)
+STATUS:CONFIRMED
+CREATED:20230216T131740Z
+LAST-MODIFIED:20230310T145759Z
+SEQUENCE:4
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RELATED-TO:1c392e72-6df9-4c18-b02a-f7f556749763
+RELATED-TO:34554f1f-4033-474a-933d-ad4244f5a25b
+RRULE:FREQ=WEEKLY;UNTIL=20230313T130000Z;INTERVAL=1;BYDAY=TU;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:e62950a1-4c4e-4145-8de4-acdef4c3c448
+DTSTAMP:20230310T145759Z
+SUMMARY:WoT Use Case
+DTSTART;TZID=Europe/Berlin:20230307T140000
+DTEND;TZID=Europe/Berlin:20230307T150000
+DESCRIPTION:https://www.w3.org/events/meetings/e62950a1-4c4e-4145-8de4-acde
+ f4c3c448/20230307T140000\n\nThe [WoT Use Case task force](https://www.w3.o
+ rg/WoT/IG/wiki/IG_UseCase_WebConf) is responsible for collecting use cases
+  for WoT and extracting requirements. Use cases can include both specific 
+ vertical applications as well as relevant horizontal technologies or other
+  horizontal usage patterns. Guests who are not WoT members but who have an
+  interest in specific vertical application domains\, technologies\, or usa
+ ge patterns are explicitly invited to engage with this task force to provi
+ de input.\n\n[IRC: #wot-uc](https://irc.w3.org/?channels=wot-uc)
+STATUS:CONFIRMED
+CREATED:20230307T130408Z
+LAST-MODIFIED:20230310T145759Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RECURRENCE-ID;TZID=Europe/Berlin:20230307T140000
+END:VEVENT
+BEGIN:VEVENT
+UID:34554f1f-4033-474a-933d-ad4244f5a25b
+DTSTAMP:20230530T121311Z
+SUMMARY:WoT Use Case
+DTSTART;TZID=America/New_York:20230314T080000
+DTEND;TZID=America/New_York:20230314T090000
+DESCRIPTION:https://www.w3.org/events/meetings/34554f1f-4033-474a-933d-ad42
+ 44f5a25b\n\nThe [WoT Use Case task force](https://www.w3.org/WoT/IG/wiki/I
+ G_UseCase_WebConf) is responsible for collecting use cases for WoT and ext
+ racting requirements. Use cases can include both specific vertical applica
+ tions as well as relevant horizontal technologies or other horizontal usag
+ e patterns. Guests who are not WoT members but who have an interest in spe
+ cific vertical application domains\, technologies\, or usage patterns are 
+ explicitly invited to engage with this task force to provide input.\n\n[IR
+ C: #wot-uc](https://irc.w3.org/?channels=wot-uc)
+STATUS:CONFIRMED
+CREATED:20230309T121711Z
+LAST-MODIFIED:20230530T121311Z
+SEQUENCE:5
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+RELATED-TO:e62950a1-4c4e-4145-8de4-acdef4c3c448
+RELATED-TO:887c81ab-1ee1-49de-8353-17468efd76dd
+RRULE:FREQ=WEEKLY;UNTIL=20230523T120000Z;INTERVAL=1;BYDAY=TU;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:887c81ab-1ee1-49de-8353-17468efd76dd
+DTSTAMP:20230530T121311Z
+SUMMARY:WoT Use Case - TEMPORARILY SUSPENDED
+DTSTART;TZID=America/New_York:20230530T080000
+DTEND;TZID=America/New_York:20230530T090000
+DESCRIPTION:https://www.w3.org/events/meetings/887c81ab-1ee1-49de-8353-1746
+ 8efd76dd\n\nTEMPORARILY SUSPENDED UNTIL NEW CHARTER STARTS\n\nThe [WoT Use
+  Case task force](https://www.w3.org/WoT/IG/wiki/IG_UseCase_WebConf) is re
+ sponsible for collecting use cases for WoT and extracting requirements. Us
+ e cases can include both specific vertical applications as well as relevan
+ t horizontal technologies or other horizontal usage patterns. Guests who a
+ re not WoT members but who have an interest in specific vertical applicati
+ on domains\, technologies\, or usage patterns are explicitly invited to en
+ gage with this task force to provide input.\n\n[IRC: #wot-uc](https://irc.
+ w3.org/?channels=wot-uc)
+STATUS:TENTATIVE
+CREATED:20230530T121311Z
+LAST-MODIFIED:20230530T121311Z
+SEQUENCE:4
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:Zoom TBD
+RELATED-TO:34554f1f-4033-474a-933d-ad4244f5a25b
+RRULE:FREQ=WEEKLY;UNTIL=20230531T120000Z;INTERVAL=1;BYDAY=TU;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:4af29174-e472-412b-9429-5dc01b3588e2
+DTSTAMP:20230130T072105Z
+SUMMARY:WoT Use Case
+DTSTART;TZID=Europe/Berlin:20230131T140000
+DTEND;TZID=Europe/Berlin:20230131T150000
+DESCRIPTION:https://www.w3.org/events/meetings/4af29174-e472-412b-9429-5dc0
+ 1b3588e2\n\nThe [WoT Use Case task force](https://www.w3.org/WoT/IG/wiki/I
+ G_UseCase_WebConf) is responsible for collecting use cases for WoT and ext
+ racting requirements. Use cases can include both specific vertical applica
+ tions as well as relevant horizontal technologies or other horizontal usag
+ e patterns. Guests who are not WoT members but who have an interest in spe
+ cific vertical application domains\, technologies\, or usage patterns are 
+ explicitly invited to engage with this task force to provide input.\n\n[IR
+ C: #wot-uc](https://irc.w3.org/?channels=wot-uc) / [WebEx](https://lists.w
+ 3.org/Archives/Member/member-wot-wg/2021Mar/0044.html)
+STATUS:TENTATIVE
+CREATED:20230130T072105Z
+LAST-MODIFIED:20230130T072105Z
+SEQUENCE:0
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+RRULE:FREQ=WEEKLY;UNTIL=20231216T130000Z;INTERVAL=2;BYDAY=TU;WKST=MO
+END:VEVENT
+BEGIN:VEVENT
+UID:91a2680d-8808-4948-836d-bf64569b708d
+DTSTAMP:20230212T232909Z
+SUMMARY:WoT Charter - 2nd Session - Day 1
+DTSTART;TZID=America/New_York:20230214T070000
+DTEND;TZID=America/New_York:20230214T090000
+DESCRIPTION:https://www.w3.org/events/meetings/91a2680d-8808-4948-836d-bf64
+ 569b708d\n\n----------------------------\n2nd WoT WG Charter Meeting\n----
+ ------------------------\n\nDay 1: Tuesday\, Feb 14 - Marketing/Use Cases 
+ slots\n------------------------------------------------------------------\
+ n04:00-06:00 PST\n07:00-09:00 EST\n08:00-10:00 AST\n12:00-14:00 UTC\n13:00
+ -15:00 CET\n21:00-23:00 JST\n\nSee also:\nhttps://www.timeanddate.com/worl
+ dclock/converter.html?iso=20230214T120000&p1=137&p2=43&p3=tz_at&p4=1440&p5
+ =136&p6=195&p7=101&p8=33&p9=236&p10=248
+STATUS:CONFIRMED
+CREATED:20230212T230406Z
+LAST-MODIFIED:20230212T232909Z
+SEQUENCE:3
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+END:VEVENT
+BEGIN:VEVENT
+UID:fdf5f2e3-5799-4565-a472-ce093fb9e814
+DTSTAMP:20230212T233006Z
+SUMMARY:WoT Charter - 2nd Session - Day 2
+DTSTART;TZID=America/New_York:20230215T080000
+DTEND;TZID=America/New_York:20230215T100000
+DESCRIPTION:https://www.w3.org/events/meetings/fdf5f2e3-5799-4565-a472-ce09
+ 3fb9e814\n\nDay 2: Wednesday\, Feb 15 - Main call/Testing slots\n---------
+ ---------------------------------------------------------\n05:00-07:00 PST
+ \n08:00-10:00 EST\n09:00-11:00 AST\n13:00-15:00 UTC\n14:00-16:00 CET\n22:0
+ 0-24:00 JST\n\nSee also:\nhttps://www.timeanddate.com/worldclock/converter
+ .html?iso=20230215T130000&p1=137&p2=43&p3=tz_at&p4=1440&p5=136&p6=195&p7=1
+ 01&p8=33&p9=236&p10=248
+STATUS:CONFIRMED
+CREATED:20230212T230703Z
+LAST-MODIFIED:20230212T233006Z
+SEQUENCE:1
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+END:VEVENT
+BEGIN:VEVENT
+UID:3f0cea28-a4e6-44e8-8795-23181342a2dc
+DTSTAMP:20230213T130240Z
+SUMMARY:WoT Charter - 2nd Session - Day 3
+DTSTART;TZID=America/New_York:20230216T060000
+DTEND;TZID=America/New_York:20230216T080000
+DESCRIPTION:https://www.w3.org/events/meetings/3f0cea28-a4e6-44e8-8795-2318
+ 1342a2dc\n\n03:00-05:00 PST\n06:00-08:00 EST\n07:00-09:00 AST\n11:00-13:00
+  UTC\n12:00-14:00 CET\n20:00-22:00 JST\n\nSee also: https://www.timeanddat
+ e.com/worldclock/converter.html?iso=20230216T110000&p1=137&p2=43&p3=tz_at&
+ p4=1440&p5=136&p6=195&p7=101&p8=33&p9=236&p10=248
+STATUS:CONFIRMED
+CREATED:20230213T075041Z
+LAST-MODIFIED:20230213T130240Z
+SEQUENCE:2
+ORGANIZER;CN=W3C Calendar;PARTSTAT=ACCEPTED;ROLE=NON-PARTICIPANT:mailto:nor
+ eply@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Inte
+ rest Group:mailto:public-wot-ig@w3.org
+ATTENDEE;CUTYPE=GROUP;ROLE=OPT-PARTICIPANT;RSVP=FALSE;CN=Web of Things Work
+ ing Group:mailto:public-wot-wg@w3.org
+LOCATION:WebEx
+END:VEVENT
+END:VCALENDAR


### PR DESCRIPTION
TODOs:
* [ ] use online ICS file instead of local one (easier for now w.r.t. testing)
* [x] add complete list of timezones in TZ selector
* [x] listen onload events to collect W3C events
* [ ] start website with local timezone as we used to have?
* [ ] rephrase intro text "We have grouped our weekly meetings in the table below...."
* [x] limit view to weekdays only


ISSUES:
* [ ] changing week to month view does not reload timezone correctly
* [ ] moment(..) always reports local time
* [ ] repeat events not shown after TZ changer
* [x] avoid calendar entry being editable


fixes https://github.com/w3c/wot-marketing/issues/268