### PR TITLE
fix GitHub editing shortcut using master as branch name

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -43,7 +43,7 @@
 
   <body>
 	  <!-- GitHub corner -->
-	<a target="_blank" href="https://www.github.com/{{ site.github_username }}/{{ site.git_repo }}/blob/master/docs/{{ page.path }}" class="github-corner" aria-label="View source on GitHub" id="#edit-button"><svg width="40" height="40"
+	<a target="_blank" href="https://www.github.com/{{ site.github_username }}/{{ site.git_repo }}/blob/main/docs/{{ page.path }}" class="github-corner" aria-label="View source on GitHub" id="#edit-button"><svg width="40" height="40"
 			viewBox="0 0 250 250" style="fill:#005A9C; color:#fff; position: absolute; top: 0; border: 0; right: 0;"
 			aria-hidden="true">
 			<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>


### PR DESCRIPTION
Clicking on the icon top right results in the following warning. A small fix for that.

![image](https://github.com/w3c/wot-marketing/assets/20195407/f86b78cb-6612-4ecb-9f8f-a31ef0e30b30)
