### PR TITLE
Align TF leads and Editors

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -61,6 +61,7 @@ GEM
 
 PLATFORMS
   universal-darwin-22
+  universal-darwin-23
   x64-unknown
   x86_64-linux
 

--- a/docs/activities/task-forces/tf-architecture/index.html
+++ b/docs/activities/task-forces/tf-architecture/index.html
@@ -39,17 +39,19 @@ group: "navigation"
     <div>
         <h3>People</h3>
 	<dl>
-        <dt>TF-Lead:</dt><dd>
-            Michael Lagally (Oracle Corp.)
+        <dt>TF-Leads:</dt><dd>
+            Michael Lagally (Oracle Corp.) and
+            Michael McCool (Intel Corp.)
         </dd>
         <dt>WoT Architecture Co-Editors:</dt><dd>
             Michael Lagally (Oracle Corp.),
             Ryuichi Matsukura (Fujitsu Ltd.),
-            Toru Kawaguchi (Panasonic Corp.), and
+            Michael McCool (Intel Corp.), and
             Kunihiko Toumura (Hitachi, Ltd.)
         </dd>
         <dt>WoT Profile Co-Editors:</dt><dd>
             Michael Lagally (Oracle Corp.),
+            Ben Francis (Invited Expert)
             Michael McCool (Intel Corp.),
             Ryuichi Matsukura (Fujitsu Ltd.),
             Sebastian Kaebisch (Siemens AG), and

--- a/docs/activities/task-forces/tf-plugfest/index.html
+++ b/docs/activities/task-forces/tf-plugfest/index.html
@@ -4,24 +4,26 @@ title: Plugfest/Testing Task Force
 group: "navigation"
 ---
 <div>
-<h2>W3C WoT – Plugfest/Testing Task Force</h2>
-    <p>The WoT Plugfest/Testing task force is responsible for organizing the Web of 
-        Things (WoT) Plugfests and also for organizing general testing procedures, 
-        data collection, and implementation report tooling for WoT deliverables. 
+    <h2>W3C WoT – Plugfest/Testing Task Force</h2>
+    <p>The WoT Plugfest/Testing task force is responsible for organizing the Web of
+        Things (WoT) Plugfests and also for organizing general testing procedures,
+        data collection, and implementation report tooling for WoT deliverables.
     </p>
     <div>
         <h3>People</h3>
-	<dl>
-		<dt>TF-Lead:</dt><dd>
-		    Fady Salama (Siemens AG)
-		</dd>
-	</dl>
+        <dl>
+            <dt>TF-Lead:</dt>
+            <dd>
+                Michael McCool (Intel)
+            </dd>
+        </dl>
     </div>
     <div>
         <h3>Resources</h3>
-	<ul>
-        <li><a href="https://www.w3.org/WoT/IG/wiki/PlugFest_WebConf" target="_blank">WoT Plugfest/Testing TF Wiki (has meeting logistics)</a></li>
-        <li><a href="https://github.com/w3c/wot-testing" target="_blank">WoT Testing GitHub repository</a></li>
-	</ul>
+        <ul>
+            <li><a href="https://www.w3.org/WoT/IG/wiki/PlugFest_WebConf" target="_blank">WoT Plugfest/Testing TF Wiki
+                    (has meeting logistics)</a></li>
+            <li><a href="https://github.com/w3c/wot-testing" target="_blank">WoT Testing GitHub repository</a></li>
+        </ul>
     </div>
 </div>

--- a/docs/activities/task-forces/tf-plugfest/index.html
+++ b/docs/activities/task-forces/tf-plugfest/index.html
@@ -14,7 +14,7 @@ group: "navigation"
         <dl>
             <dt>TF-Lead:</dt>
             <dd>
-                Michael McCool (Intel)
+                Michael McCool (Intel Corp.)
             </dd>
         </dl>
     </div>

--- a/docs/activities/task-forces/tf-scripting/index.html
+++ b/docs/activities/task-forces/tf-scripting/index.html
@@ -27,7 +27,7 @@ group: "navigation"
 			<dt>TF-Lead:</dt>
 			<dd>Daniel Peintner (Siemens AG) and Cristiano Aguzzi (Invited Expert)</dd>
 			<dt>WoT Scripting API Co-Editors:</dt>
-			<dd>Zoltan Kis (Intel), Daniel Peintner (Siemens AG), and Cristiano Aguzzi (Invited Expert)</dd>
+			<dd>Zoltan Kis (Intel Corp.), Daniel Peintner (Siemens AG), and Cristiano Aguzzi (Invited Expert)</dd>
 		</dl>
     </div>
     <div>

--- a/docs/activities/task-forces/tf-td/index.html
+++ b/docs/activities/task-forces/tf-td/index.html
@@ -43,16 +43,16 @@ group: "navigation"
 			<h3>People</h3>
 		<dl>
 			<dt>TF-Lead:</dt><dd>
-				Sebastian Kaebisch (Siemens AG)
+				Ege Korkan (Siemens AG) and
+				Michael Koster (Invited Expert)
 			</dd>
 			<dt>WoT Thing Description Co-Editors:</dt><dd>
 				Sebastian Kaebisch (Siemens AG),
-				Takuki Kamiya (Fujitsu Laboratories of America),
-				Michael McCool (Intel),
-				Victor Charpenay (Siemens AG)
+				Michael McCool (Intel Corp.),
+				Ege Korkan (Siemens AG)
 			</dd>
 			<dt>WoT Binding Templates:</dt><dd>
-				Michael Koster (SmartThings),
+				Michael Koster (Invited Expert),
 				Ege Korkan (Siemens AG) 
 			</dd>
 		</dl>

--- a/docs/ig/index.html
+++ b/docs/ig/index.html
@@ -8,7 +8,7 @@ group: "navigation"
 	<p>
 		The W3C WoT Interest Group (IG) plays a complementary role to the Working Group. The IG organizes and runs PlugFests to evaluate the current working assumptions, reaches out and collaborates with interested organizations, vendors, and communities, and explores new areas to identify work that is ready for transfer to the W3C Recommendation Track (i.e., any W3C Working Group).
 	</p>
-	<p>Co-Chairs: <a href="mailto:michael.mccool@intel.com">Michael McCool (Intel)</a> and <a href="mailto:sebastian.kaebisch@siemens.com">Sebastian K&auml;bisch (Siemens AG)</a></p>
+	<p>Co-Chairs: <a href="mailto:michael.mccool@intel.com">Michael McCool (Intel Corp.)</a> and <a href="mailto:sebastian.kaebisch@siemens.com">Sebastian K&auml;bisch (Siemens AG)</a></p>
 	<p>Team contacts: <a href="https://www.w3.org/People#ashimura" target="_blank">Kazuyuki Ashimura</a> and <a href="https://www.w3.org/People#dsr" target="_blank">Dave Raggett</a></p>
 	
 	<p>&nbsp;</p>
@@ -62,7 +62,7 @@ group: "navigation"
 				<tr>
 					<td><a href="{{'activities/task-forces/tf-plugfest/' | relative_url }}">WoT Plugfest</a></td>
 					<td style="text-align:center;">WoT Plugfest</td>
-					<td style="text-align:right;"><a href="mailto:fady.salama.ext@siemens.com">Fady Salama (Siemens AG)</a></td>
+					<td style="text-align:right;"><a href="mailto:michael.mccool@intel.com">Michael McCool (Intel Corp.)</a></td>
 			</table>
 		</div>
 	</div>

--- a/docs/wg/index.html
+++ b/docs/wg/index.html
@@ -70,7 +70,7 @@ group: "navigation"
 				<tr>
 					<td><a href="{{'activities/task-forces/tf-scripting/' | relative_url }}">WoT Scripting API</a></td>
 					<td style="text-align:center;">WoT Scripting</td>
-					<td style="text-align:right;"><a href="mailto:daniel.peintner.ext@siemens.com">Daniel Peintner (Siemens AG)</a> and <a href="mailto:cristiano.aguzzi@unibo.it">Cristiano Aguzzi</a></td>
+					<td style="text-align:right;"><a href="mailto:daniel.peintner.ext@siemens.com">Daniel Peintner (Siemens AG)</a> and <a href="mailto:cristiano.aguzzi@unibo.it">Cristiano Aguzzi (Invited Expert)</a></td>
 				</tr>
 			</table>
 		</div>

--- a/docs/wg/index.html
+++ b/docs/wg/index.html
@@ -8,7 +8,7 @@ group: "navigation"
 	<p>
 		The W3C WoT Working Group (WG) is tasked to create standards-track specifications and test suites. To ensure royalty-free Web standards, participants must be W3C and WoT WG Members and acknowledge the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.
 	</p>
-	<p>Co-Chairs: <a href="mailto:michael.mccool@intel.com">Michael McCool (Intel)</a>, <a href="mailto:sebastian.kaebisch@siemens.com">Sebastian K&auml;bisch (Siemens AG)</a> and <a href="mailto:michaeljohnkoster@gmail.com">Michael Koster</a></p>
+	<p>Co-Chairs: <a href="mailto:michael.mccool@intel.com">Michael McCool (Intel Corp.)</a>, <a href="mailto:sebastian.kaebisch@siemens.com">Sebastian K&auml;bisch (Siemens AG)</a> and <a href="mailto:michaeljohnkoster@gmail.com">Michael Koster</a></p>
 	<p>Team contact: <a href="https://www.w3.org/People#ashimura" target="_blank">Kazuyuki Ashimura</a></p>
 	
 	<p>&nbsp;</p>
@@ -50,27 +50,27 @@ group: "navigation"
 				<tr>
 					<td><a href="{{'activities/task-forces/tf-architecture/' | relative_url }}">WoT Architecture</a></td>
 					<td style="text-align:center;">WoT Architecture<br>WoT Profile</td>
-					<td style="text-align:right;"><a href="mailto:michael.lagally@oracle.com">Michael Lagally (Oracle Corp.)</a></td>
+					<td style="text-align:right;"><a href="mailto:michael.lagally@oracle.com">Michael Lagally (Oracle Corp.)</a> and <a href="mailto:michael.mccool@intel.com">Michael McCool (Intel Corp.)</a></td>
 				</tr>
 				<tr>
 					<td><a href="{{'activities/task-forces/tf-td/' | relative_url }}">WoT Thing Description</a></td>
 					<td style="text-align:center;">WoT Thing Description<br>WoT Binding Templates</td>
-					<td style="text-align:right;"><a href="mailto:sebastian.kaebisch@siemens.com">Sebastian K&auml;bisch (Siemens AG)</a><br></td>
+					<td style="text-align:right;"><a href="mailto:ege.korkan@siemens.com">Ege Korkan (Siemens AG)</a> and <a href="mailto:michaeljohnkoster@gmail.com">Michael Koster</a><br></td>
 				</tr>
 				<tr>
 					<td><a href="{{'activities/task-forces/tf-discovery/' | relative_url }}">WoT Discovery</a></td>
 					<td style="text-align:center;">WoT Discovery</td>
-					<td style="text-align:right;"><a href="mailto:michael.mccool@intel.com">Michael McCool (Intel)</a></td>
+					<td style="text-align:right;"><a href="mailto:michael.mccool@intel.com">Michael McCool (Intel Corp.)</a></td>
 				</tr>
 				<tr>
 					<td><a href="{{'activities/task-forces/tf-security/' | relative_url }}">WoT Security</a></td>
 					<td style="text-align:center;">WoT Security</td>
-					<td style="text-align:right;"><a href="mailto:michael.mccool@intel.com">Michael McCool (Intel)</a></td>
+					<td style="text-align:right;"><a href="mailto:michael.mccool@intel.com">Michael McCool (Intel Corp.)</a></td>
 				</tr>
 				<tr>
 					<td><a href="{{'activities/task-forces/tf-scripting/' | relative_url }}">WoT Scripting API</a></td>
 					<td style="text-align:center;">WoT Scripting</td>
-					<td style="text-align:right;"><a href="mailto:daniel.peintner.ext@siemens.com">Daniel Peintner (Siemens AG)</a></td>
+					<td style="text-align:right;"><a href="mailto:daniel.peintner.ext@siemens.com">Daniel Peintner (Siemens AG)</a> and <a href="mailto:cristiano.aguzzi@unibo.it">Cristiano Aguzzi</a></td>
 				</tr>
 			</table>
 		</div>


### PR DESCRIPTION
fixes #445

I have also changed `Intel` to `Intel Corp.` since that is what is shown at https://www.w3.org/organizations/9829/