### PR TITLE
refactor: update documentation page with recent publications

### DIFF
--- a/docs/documentation/index.html
+++ b/docs/documentation/index.html
@@ -196,17 +196,17 @@ group: "navigation"
 			<ul>
 				<li>Normative Deliverables
 					<ul>
-						<li><a href="https://www.w3.org/TR/2020/REC-wot-architecture-20200409/" target="_blank">Web of Things (WoT) Architecture (W3C Recommendation)</a></li>
-						<li><a href="https://www.w3.org/TR/2020/REC-wot-thing-description-20200409/" target="_blank">Web of Things (WoT) Thing Description (W3C Recommendation)</a></li>
-						<li><a href="https://www.w3.org/TR/2021/WD-wot-discovery-20210602/" target="_blank">Web of Things (WoT) Discovery (W3C Working Draft)</a></li>
-						<li><a href="https://www.w3.org/TR/2020/WD-wot-profile-20201124/" target="_blank">Web of Things (WoT) Profile (W3C Working Draft)</a></li>
+						<li><a href="https://www.w3.org/TR/wot-architecture/" target="_blank">Web of Things (WoT) Architecture (W3C Recommendation)</a></li>
+						<li><a href="https://www.w3.org/TR/wot-thing-description/" target="_blank">Web of Things (WoT) Thing Description (W3C Recommendation)</a></li>
+						<li><a href="https://www.w3.org/TR/wot-discovery/" target="_blank">Web of Things (WoT) Discovery (W3C Working Draft)</a></li>
+						<li><a href="https://www.w3.org/TR/wot-profile/" target="_blank">Web of Things (WoT) Profile (W3C Working Draft)</a></li>
 					</ul>
 				</li>
 				<li>Informative Deliverables 
 					<ul>
-						<li><a href="https://www.w3.org/TR/2020/NOTE-wot-scripting-api-20201124/" target="_blank">Web of Things (WoT) Scripting API (W3C Note)</a></li>
-						<li><a href="https://www.w3.org/TR/2020/NOTE-wot-binding-templates-20200130/" target="_blank">Web of Things (WoT) Binding Templates (W3C Note)</a></li>
-						<li><a href="https://www.w3.org/TR/2019/NOTE-wot-security-20191106/" target="_blank">Web of Things (WoT) Security and Privacy Guidelines (W3C Note )</a></li>
+						<li><a href="https://www.w3.org/TR/wot-scripting-api/" target="_blank">Web of Things (WoT) Scripting API (W3C Group Note)</a></li>
+						<li><a href="https://www.w3.org/TR/wot-binding-templates/" target="_blank">Web of Things (WoT) Binding Templates (W3C Group Note)</a></li>
+						<li><a href="https://www.w3.org/TR/wot-security/" target="_blank">Web of Things (WoT) Security and Privacy Guidelines (W3C Group Note)</a></li>
 					</ul>
 				</li>
 			</ul>


### PR DESCRIPTION
We use generic links in the rest of the text instead of dated URIs

Hence I do (and suggest to do) the same for the "Further Reading" section changing 
https://www.w3.org/TR/2020/REC-wot-architecture-20200409/
--> to -->
https://www.w3.org/TR/wot-architecture/

fixes https://github.com/w3c/wot-marketing/issues/375