### PR TITLE
Add Mastodon verification link to website header

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -20,6 +20,9 @@
 	<!-- Font Awesome icons -->
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
 
+    <!-- Mastodon verification link -->
+    <link ref="me" href="https://w3c.social/@wot">
+
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
       <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>


### PR DESCRIPTION
As mentioned in https://github.com/w3c/wot-marketing/issues/461#issuecomment-1864746622, this small PR proposes adding a verification link for Mastodon to the website. This way, the link on our Mastodon profile will have a "verified" checkmark, like so:

<img width="567" alt="image" src="https://github.com/w3c/wot-marketing/assets/12641361/98b0105f-6412-4dca-b5c6-cc877fcfa7d4">

This change is not really important, since our account is hosted at the W3C instance anyway, but makes the account look even more "official" ;)
