### PR TITLE
extended till 31 Mar 2024

### DIFF
--- a/docs/ig/index.html
+++ b/docs/ig/index.html
@@ -15,7 +15,7 @@ group: "navigation"
 	
 	<div class="row center-block">
 		<div class="col-md-6 text-center">
-			<a href="https://www.w3.org/2021/12/wot-ig-2021.html" target="_blank"><i class="fas fa-file-alt fa-4x"></i><div class="description"><h3>IG Charter</h3><p>Active from 10 February 2022<br/>until 31 December 2023.</p></div></a>
+			<a href="https://www.w3.org/2021/12/wot-ig-2021.html" target="_blank"><i class="fas fa-file-alt fa-4x"></i><div class="description"><h3>IG Charter</h3><p>Active from 10 February 2022<br/>until 31 March 2024.</p></div></a>
 		</div>
 		<div class="col-md-6 text-center">
 			<a href="https://lists.w3.org/Archives/Public/public-wot-ig/" target="_blank"><i class="fas fa-envelope fa-4x"></i><div class="description"><h3>Mailing List</h3><p>Public mailing list archive and sign-up.</p></div></a>


### PR DESCRIPTION
The [current WoT IG Charter](https://www.w3.org/2021/12/wot-ig-2021.html) has been extended till 31 March 2024 to accommodate the rechartering procedure.