### PR TITLE
Mastodon Integration

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -87,7 +87,10 @@ title: Home
 	
 	</div>
 	<div class="col-md-4">
-		<blockquote class="twitter-tweet"><p lang="en" dir="ltr">Hi all! From now on, we will be also active on Mastodon instance hosted by the <a href="https://twitter.com/w3c?ref_src=twsrc%5Etfw">@w3c</a> at <a href="https://t.co/6csotkx2TQ">https://t.co/6csotkx2TQ</a> <br><br>We will be active on Twitter/X as well until further notice.</p>&mdash; W3C Web of Things (@W3C_WoT) <a href="https://twitter.com/W3C_WoT/status/1737763113384997056?ref_src=twsrc%5Etfw">December 21, 2023</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script> 
+		<iframe src="https://w3c.social/@wot/111613133105805601/embed" class="mastodon-embed" style="max-width: 100%; border: 0;"
+			width="400" allowfullscreen="allowfullscreen"></iframe>
+		<script src="https://w3c.social/embed.js" async="async"></script>
+		<p>We are also active on X (formerly known as Twitter). Follow us there at <a href="https://twitter.com/W3C_WoT">@W3C_WoT.</a></p>
 	</div>
 	</div>
 	


### PR DESCRIPTION
This replaces the Twitter/X integration with a Mastodon iframe (what you get when you click embed). Sadly it is with black background and there is no way to pass CSS parameters to an iframe. To fix that, we need to fetch the data from their API or use a third-party library.