### PR TITLE
Fix Mastodon verification link

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -21,7 +21,7 @@
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
 
     <!-- Mastodon verification link -->
-    <link ref="me" href="https://w3c.social/@wot">
+    <link rel="me" href="https://w3c.social/@wot">
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>


### PR DESCRIPTION
After the merge of #463, verification has not been working yet due to a small, but critical typo. This PR fixes the issue and should get our account verified :)