### PR TITLE
update the WoT-IG page with  the information on the new IG Charter

### DIFF
--- a/docs/ig/index.html
+++ b/docs/ig/index.html
@@ -8,7 +8,7 @@ group: "navigation"
 	<p>
 		The W3C WoT Interest Group (IG) plays a complementary role to the Working Group. The IG organizes and runs PlugFests to evaluate the current working assumptions, reaches out and collaborates with interested organizations, vendors, and communities, and explores new areas to identify work that is ready for transfer to the W3C Recommendation Track (i.e., any W3C Working Group).
 	</p>
-	<p>Co-Chairs: <a href="mailto:michael.mccool@intel.com">Michael McCool (Intel Corp.)</a>, <a href="mailto:sebastian.kaebisch@siemens.com">Sebastian K&auml;bisch (Siemens AG)</a> and <a href="mailto:michaeljohnkoster@gmail.com">Michael Koster</a></p>
+	<p>Co-Chairs: <a href="mailto:michael.mccool@intel.com">Michael McCool (Intel Corp.)</a>, <a href="mailto:sebastian.kaebisch@siemens.com">Sebastian K&auml;bisch (Siemens AG)</a> and <a href="mailto:michaeljohnkoster@gmail.com">Michael Koster (Invited Expert)</a></p>
 	<p>Team contact: <a href="https://www.w3.org/People#ashimura">Kazuyuki Ashimura</a></p>
 	
 	<p>&nbsp;</p>

--- a/docs/ig/index.html
+++ b/docs/ig/index.html
@@ -8,14 +8,14 @@ group: "navigation"
 	<p>
 		The W3C WoT Interest Group (IG) plays a complementary role to the Working Group. The IG organizes and runs PlugFests to evaluate the current working assumptions, reaches out and collaborates with interested organizations, vendors, and communities, and explores new areas to identify work that is ready for transfer to the W3C Recommendation Track (i.e., any W3C Working Group).
 	</p>
-	<p>Co-Chairs: <a href="mailto:michael.mccool@intel.com">Michael McCool (Intel Corp.)</a> and <a href="mailto:sebastian.kaebisch@siemens.com">Sebastian K&auml;bisch (Siemens AG)</a></p>
-	<p>Team contacts: <a href="https://www.w3.org/People#ashimura">Kazuyuki Ashimura</a> and <a href="https://www.w3.org/People#dsr">Dave Raggett</a></p>
+	<p>Co-Chairs: <a href="mailto:michael.mccool@intel.com">Michael McCool (Intel Corp.)</a>, <a href="mailto:sebastian.kaebisch@siemens.com">Sebastian K&auml;bisch (Siemens AG)</a> and <a href="mailto:michaeljohnkoster@gmail.com">Michael Koster</a></p>
+	<p>Team contact: <a href="https://www.w3.org/People#ashimura">Kazuyuki Ashimura</a></p>
 	
 	<p>&nbsp;</p>
 	
 	<div class="row center-block">
 		<div class="col-md-6 text-center">
-			<a href="https://www.w3.org/2021/12/wot-ig-2021.html"><i class="fas fa-file-alt fa-4x"></i><div class="description"><h3>IG Charter</h3><p>Active from 10 February 2022<br/>until 30 June 2024.</p></div></a>
+			<a href="https://www.w3.org/2024/04/wot-ig-2024.html"><i class="fas fa-file-alt fa-4x"></i><div class="description"><h3>IG Charter</h3><p>Active from 20 May 2024<br/>until 19 May 2026.</p></div></a>
 		</div>
 		<div class="col-md-6 text-center">
 			<a href="https://lists.w3.org/Archives/Public/public-wot-ig/"><i class="fas fa-envelope fa-4x"></i><div class="description"><h3>Mailing List</h3><p>Public mailing list archive and sign-up.</p></div></a>


### PR DESCRIPTION
The new WoT-IG Charter has been approved and the Call-for-Participation message has been sent out.

So we need to update the WoT-IG page according to the [new IG Charter](https://www.w3.org/2024/04/wot-ig-2024.html).