### PR TITLE
Remove twitter link on contact page

### DIFF
--- a/docs/about/contact/index.html
+++ b/docs/about/contact/index.html
@@ -61,17 +61,9 @@ td {
 		<tr>
 			<td style="vertical-align: top;">General Comments</td>
 			<td>
-				<li>
-					<a href="https://w3c.social/@wot">
-					<img height="20px" alt="Mastodon" src="https://www.cdnlogo.com/logos/m/33/mastodon.svg">
+				<a href="https://w3c.social/@wot">
+				<img height="20px" alt="Mastodon" src="https://www.cdnlogo.com/logos/m/33/mastodon.svg">
 					@wot@w3c.social</a>
-				</li>
-				<li>
-					<a href="https://twitter.com/W3C_WoT">
-						<img height="20px" alt="Twitter" src="https://cdn.cdnlogo.com/logos/t/39/twitter.svg" />
-						@W3C_WoT
-					</a>
-				</li>
 			</td>
 		</tr>
 	</table>


### PR DESCRIPTION
follow-up for https://github.com/w3c/wot-marketing/pull/551